### PR TITLE
feat: substring contains operators for arr tags

### DIFF
--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -194,6 +194,8 @@ OPERATOR_LABELS: dict[str, str] = {
     "not_contains_any": "matches none",
     "contains_all": "matches all",
     "not_contains_all": "does not match all",
+    "contains_substring": "contains",
+    "not_contains_substring": "does not contain",
     "exists": "exists",
     "not_exists": "missing",
     "is_true": "is true",
@@ -388,6 +390,10 @@ MULTI_VALUE_TEXT_OPERATORS = {
     "exists",
     "not_exists",
 }
+TAG_SUBSTRING_OPERATORS = {
+    "contains_substring",
+    "not_contains_substring",
+}
 TEMPORAL_OPERATORS = {
     "exists",
     "not_exists",
@@ -417,6 +423,7 @@ FIELD_ALLOWED_OPERATORS: dict[str, set[str]] = {
     "media_server.collections": set(MULTI_VALUE_TEXT_OPERATORS),
     "playback.usernames": set(MULTI_VALUE_TEXT_OPERATORS),
     "seerr.requested_by_user_ids": set(SEERR_REQUESTER_ID_OPERATORS),
+    "arr.tags": set(TEXT_OPERATORS) | TAG_SUBSTRING_OPERATORS,
 }
 
 TARGET_SCOPE_ALLOWED_FIELDS: dict[str, set[str]] = {
@@ -2039,6 +2046,15 @@ def _matches_operator(
         return _matches_any_regex(_as_list(actual), _as_list(expected))
     if operator in LIST_OPERATORS:
         return _matches_list_operator(actual, operator, expected, field=field)
+    if operator in TAG_SUBSTRING_OPERATORS:
+        needles = [_normalize(item) for item in _as_list(expected) if _exists(item)]
+        if not needles:
+            return False
+        haystacks = [_normalize(item) for item in _as_list(actual) if _exists(item)]
+        found = any(
+            needle in haystack for haystack in haystacks for needle in needles
+        )
+        return found if operator == "contains_substring" else not found
     if field in MULTI_VALUE_TEXT_FIELDS and operator in {"equals", "not_equals"}:
         list_operator = "contains_any" if operator == "equals" else "not_contains_any"
         return _matches_list_operator(actual, list_operator, expected, field=field)

--- a/docs/usage/rules.md
+++ b/docs/usage/rules.md
@@ -85,6 +85,23 @@ size field.
 Text and list comparisons are case-insensitive unless a field documents
 additional normalization.
 
+### Substring Operators (Arr tags)
+
+The Arr tags field matches whole tag names with the list operators above. It
+also supports substring matching, which matches a tag by a fragment of its
+name. Each operator takes comma-separated terms with the same any/none
+behavior as `matches any` and `matches none`.
+
+| Internal operator        | UI label         | Meaning                            |
+| ------------------------ | ---------------- | ---------------------------------- |
+| `contains_substring`     | contains         | Some tag contains one of the terms |
+| `not_contains_substring` | does not contain | No tag contains any of the terms   |
+
+For example, `contains chart` matches a tag such as `weekly-chart-2024`, and
+`contains chart, -best` matches a tag containing either fragment. To require
+several fragments at once, combine `contains` conditions with an AND group. A
+blank term matches nothing.
+
 ### Missing Values
 
 `exists` matches populated metadata. `does not exist` matches missing or empty

--- a/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
+++ b/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
@@ -164,6 +164,8 @@
     not_contains_any: "matches none",
     contains_all: "matches all",
     not_contains_all: "does not match all",
+    contains_substring: "contains",
+    not_contains_substring: "does not contain",
     exists: "exists",
     not_exists: "does not exist",
     is_true: "is true",
@@ -178,6 +180,8 @@
     "not_contains_any",
     "contains_all",
     "not_contains_all",
+    "contains_substring",
+    "not_contains_substring",
     "matches_any_regex",
   ]);
 
@@ -219,6 +223,12 @@
     "not_contains_all",
     "exists",
     "not_exists",
+  ];
+
+  const arrTagsOperators: RuleConditionOperator[] = [
+    ...multiValueTextOperators,
+    "contains_substring",
+    "not_contains_substring",
   ];
 
   const libraryOperators: RuleConditionOperator[] = [
@@ -896,7 +906,7 @@
       value: "arr.tags",
       label: "Arr tags",
       kind: "text",
-      operators: multiValueTextOperators,
+      operators: arrTagsOperators,
       defaultOperator: "contains_any",
     },
     {

--- a/frontend/src/lib/types/shared.ts
+++ b/frontend/src/lib/types/shared.ts
@@ -401,6 +401,8 @@ export type RuleConditionOperator =
   | "not_contains_any"
   | "contains_all"
   | "not_contains_all"
+  | "contains_substring"
+  | "not_contains_substring"
   | "exists"
   | "not_exists"
   | "is_true"

--- a/tests/test_rule_engine_validation.py
+++ b/tests/test_rule_engine_validation.py
@@ -646,5 +646,101 @@ class RuleDefinitionValidationTests(unittest.TestCase):
             )
 
 
+class ArrTagSubstringOperatorTests(unittest.TestCase):
+    def test_contains_substring_matches_partial_tag(self) -> None:
+        tags = ["weekly-chart-2024", "drama"]
+        self.assertTrue(
+            _matches_operator(tags, "contains_substring", "chart", field="arr.tags")
+        )
+
+    def test_contains_substring_is_case_insensitive(self) -> None:
+        tags = ["Weekly-Chart-2024"]
+        self.assertTrue(
+            _matches_operator(tags, "contains_substring", "CHART", field="arr.tags")
+        )
+
+    def test_contains_substring_no_match(self) -> None:
+        tags = ["drama", "comedy"]
+        self.assertFalse(
+            _matches_operator(tags, "contains_substring", "chart", field="arr.tags")
+        )
+
+    def test_contains_substring_blank_term_fails_closed(self) -> None:
+        self.assertFalse(
+            _matches_operator(["drama"], "contains_substring", "   ", field="arr.tags")
+        )
+
+    def test_not_contains_substring_matches_when_absent(self) -> None:
+        tags = ["drama", "comedy"]
+        self.assertTrue(
+            _matches_operator(
+                tags, "not_contains_substring", "chart", field="arr.tags"
+            )
+        )
+
+    def test_not_contains_substring_no_match_when_present(self) -> None:
+        self.assertFalse(
+            _matches_operator(
+                ["weekly-chart-2024"],
+                "not_contains_substring",
+                "chart",
+                field="arr.tags",
+            )
+        )
+
+    def test_not_contains_substring_blank_term_fails_closed(self) -> None:
+        self.assertFalse(
+            _matches_operator(["drama"], "not_contains_substring", "", field="arr.tags")
+        )
+
+    def test_contains_substring_matches_any_of_multiple_terms(self) -> None:
+        tags = ["weekly-chart-2024", "drama"]
+        self.assertTrue(
+            _matches_operator(
+                tags, "contains_substring", ["xyz", "chart"], field="arr.tags"
+            )
+        )
+
+    def test_contains_substring_list_no_match_when_none_present(self) -> None:
+        tags = ["drama", "comedy"]
+        self.assertFalse(
+            _matches_operator(
+                tags, "contains_substring", ["chart", "-best"], field="arr.tags"
+            )
+        )
+
+    def test_not_contains_substring_list_matches_when_none_present(self) -> None:
+        tags = ["drama", "comedy"]
+        self.assertTrue(
+            _matches_operator(
+                tags, "not_contains_substring", ["chart", "-best"], field="arr.tags"
+            )
+        )
+
+    def test_not_contains_substring_list_no_match_when_one_present(self) -> None:
+        tags = ["top-best", "drama"]
+        self.assertFalse(
+            _matches_operator(
+                tags, "not_contains_substring", ["chart", "-best"], field="arr.tags"
+            )
+        )
+
+    def test_validation_accepts_substring_operator_on_arr_tags(self) -> None:
+        validate_rule_definition(
+            _definition("arr.tags", "contains_substring", "chart"),
+            target_scope=TARGET_MOVIE_VERSION,
+        )
+
+    def test_validation_rejects_substring_operator_on_non_tag_field(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported rule operator 'contains_substring' for field 'tmdb.genres'",
+        ):
+            validate_rule_definition(
+                _definition("tmdb.genres", "contains_substring", "chart"),
+                target_scope=TARGET_MOVIE_VERSION,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds two operators to the Arr tags rule field so rules can match tags by a
fragment of the tag name instead of the whole name:

- `contains_substring` ("contains") — matches when a tag contains one of the terms
- `not_contains_substring` ("does not contain") — matches when no tag contains any term

For example, `contains chart` matches a tag such as `weekly-chart-2024`. Both
operators accept comma-separated terms with the same any/none semantics as the
existing `matches any` / `matches none` operators, so `contains chart, -best`
matches a tag containing either fragment. Requiring several fragments at once is
done with an AND group, mirroring how the exact-match operators already compose.
Comparisons are case-insensitive; a blank term matches nothing.

Existing exact-match tag operators are unchanged, and the new operators are
scoped to `arr.tags` only.

## Changes

- Backend (`rule_engine.py`): new operator labels, an `arr.tags`-only allow-list
  entry, and a substring match branch in `_matches_operator`.
- Frontend: the operators are offered on the Arr tags field in the rule editor
  with a comma-separated value input.
- Docs: a "Substring operators" note under Rules → Operators.

## Tests

- Added unit tests in `tests/test_rule_engine_validation.py` covering match/no-match,
  case-insensitivity, blank-term fail-closed, comma-separated any/none, and
  validation (accepted on `arr.tags`, rejected elsewhere).
- Full backend suite passes (`uv run pytest`); `ruff` and `mypy` clean; frontend
  `svelte-check` clean.