### PR TITLE
feat: regex match operators for arr tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added task memory logging and cleanup for heavy sync, cleanup scan, playback, IMDb, and AniList tasks
 - Task execution modes are now explicit, with heavy tasks isolated and lightweight tasks kept inline
 - Now logs memory snap shots in debug mode
+- Arr tags rule conditions can now match with regular expressions (`matches regex` / `does not match regex`)
 
 ### Changed
 

--- a/backend/api/routes/rules.py
+++ b/backend/api/routes/rules.py
@@ -12,9 +12,11 @@ from backend.api.candidate_views import build_rule_preview_items
 from backend.core.auth import require_admin
 from backend.core.logger import LOG
 from backend.core.rule_engine import (
+    REGEX_OPERATORS,
     RULE_OUTCOME_CANDIDATE,
     RULE_OUTCOME_PROTECT,
     TARGET_MOVIE_VERSION,
+    collect_rule_conditions,
     collect_rule_path_conditions,
     derive_path_scope_library_ids,
     normalize_rule_definition,
@@ -492,6 +494,26 @@ def _validate_definition_path_syntax(definition: dict[str, Any] | None) -> None:
             ) from exc
 
 
+def _validate_definition_tag_regex_syntax(definition: dict[str, Any] | None) -> None:
+    """Validate arr.tags regex patterns for syntax, without requiring indexed media."""
+    for condition in collect_rule_conditions(definition, field="arr.tags"):
+        operator = str(condition.get("operator", "")).lower()
+        if operator not in REGEX_OPERATORS:
+            continue
+        raw = condition.get("value")
+        patterns = raw if isinstance(raw, list) else [raw]
+        for pattern in patterns:
+            if pattern is None:
+                continue
+            try:
+                re.compile(str(pattern), re.IGNORECASE)
+            except re.error as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid regex pattern '{pattern}'",
+                ) from exc
+
+
 @router.get("/rules/path-tree")
 async def get_path_tree(
     _admin: Annotated[User, Depends(require_admin)],
@@ -949,6 +971,7 @@ async def create_rule(
         rule_data.target_scope, rule_data.media_type
     )
     _validate_definition_path_syntax(rule_data.definition)
+    _validate_definition_tag_regex_syntax(rule_data.definition)
     new_rule = ReclaimRule(
         name=rule_data.name,
         media_type=effective_media_type,
@@ -1078,6 +1101,7 @@ async def preview_rule_matches(
 
     effective_media_type = _media_type_for_target(body.target_scope, body.media_type)
     _validate_definition_path_syntax(body.definition)
+    _validate_definition_tag_regex_syntax(body.definition)
 
     preview_rule = ReclaimRule(
         name=(body.name or "").strip() or "Preview Rule",
@@ -1151,6 +1175,7 @@ async def import_rules(
             except ValueError as e:
                 raise ValueError(str(e)) from e
             _validate_definition_path_syntax(rule_data.definition)
+            _validate_definition_tag_regex_syntax(rule_data.definition)
 
             name = rule_data.name
             if name in used_names:
@@ -1257,6 +1282,7 @@ async def update_rule(
             ) from e
 
         _validate_definition_path_syntax(effective_definition)
+        _validate_definition_tag_regex_syntax(effective_definition)
 
     for field, value in update_data.items():
         setattr(rule, field, value)

--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -227,7 +227,8 @@ OPERATOR_LABELS: dict[str, str] = {
     "not_exists": "missing",
     "is_true": "is true",
     "is_false": "is false",
-    "matches_any_regex": "matches path",
+    "matches_any_regex": "matches regex",
+    "not_matches_any_regex": "does not match regex",
 }
 
 LIST_OPERATORS = {
@@ -238,6 +239,7 @@ LIST_OPERATORS = {
     "contains_all",
     "not_contains_all",
     "matches_any_regex",
+    "not_matches_any_regex",
 }
 VALUELESS_OPERATORS = {"exists", "not_exists", "is_true", "is_false"}
 NUMERIC_FIELDS = {
@@ -435,6 +437,7 @@ TAG_SUBSTRING_OPERATORS = {
     "contains_substring",
     "not_contains_substring",
 }
+REGEX_OPERATORS = {"matches_any_regex", "not_matches_any_regex"}
 TEMPORAL_OPERATORS = {
     "exists",
     "not_exists",
@@ -467,7 +470,7 @@ FIELD_ALLOWED_OPERATORS: dict[str, set[str]] = {
     "seerr.requested_by_user_ids": set(SEERR_REQUESTER_ID_OPERATORS),
     "arr.movie_ids": set(SEERR_REQUESTER_ID_OPERATORS),
     "arr.series_ids": set(SEERR_REQUESTER_ID_OPERATORS),
-    "arr.tags": set(TEXT_OPERATORS) | TAG_SUBSTRING_OPERATORS,
+    "arr.tags": set(TEXT_OPERATORS) | TAG_SUBSTRING_OPERATORS | REGEX_OPERATORS,
 }
 
 TARGET_SCOPE_ALLOWED_FIELDS: dict[str, set[str]] = {
@@ -2411,8 +2414,11 @@ def _matches_operator(
         return actual is True
     if operator == "is_false":
         return actual is False
-    if operator == "matches_any_regex":
-        return _matches_any_regex(_as_list(actual), _as_list(expected))
+    if operator in REGEX_OPERATORS:
+        matched = _matches_any_regex(_as_list(actual), _as_list(expected), field=field)
+        if matched is None:  # no valid pattern: fail closed for both operators
+            return False
+        return matched if operator == "matches_any_regex" else not matched
     if operator in LIST_OPERATORS:
         return _matches_list_operator(actual, operator, expected, field=field)
     if operator in TAG_SUBSTRING_OPERATORS:
@@ -2591,19 +2597,33 @@ def _matches_path_prefix(actual: Any, expected: Any) -> bool:
     return actual_path == expected_path or actual_path.startswith(f"{expected_path}/")
 
 
-def _matches_any_regex(values: list[Any], patterns: list[Any]) -> bool:
-    """Evaluate whether any of the provided values match any of the provided regex patterns."""
-    normalized_values = [
-        normalize_fpath(value, lower=True) for value in values if _exists(value)
-    ]
+def _matches_any_regex(
+    values: list[Any], patterns: list[Any], *, field: str | None = None
+) -> bool | None:
+    """Return whether any value matches any regex pattern.
+
+    Returns ``None`` when no supplied pattern compiles, so callers can fail
+    closed for both the positive and negated operators. Path fields are
+    path-normalized; all other fields (e.g. ``arr.tags``) use plain string
+    normalization.
+    """
+    compiled: list[re.Pattern[str]] = []
     for pattern in patterns:
         try:
-            regex = re.compile(str(pattern), re.IGNORECASE)
+            compiled.append(re.compile(str(pattern), re.IGNORECASE))
         except re.error:
             continue
-        if any(regex.search(value) for value in normalized_values):
-            return True
-    return False
+    if not compiled:
+        return None
+    if field in PATH_FIELDS:
+        normalized_values = [
+            normalize_fpath(value, lower=True) for value in values if _exists(value)
+        ]
+    else:
+        normalized_values = [_normalize(value) for value in values if _exists(value)]
+    return any(
+        regex.search(value) for regex in compiled for value in normalized_values
+    )
 
 
 def _path_basename(path: str | None) -> str | None:

--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -2609,6 +2609,8 @@ def _matches_any_regex(
     """
     compiled: list[re.Pattern[str]] = []
     for pattern in patterns:
+        if not _exists(pattern):
+            continue
         try:
             compiled.append(re.compile(str(pattern), re.IGNORECASE))
         except re.error:

--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -2623,9 +2623,7 @@ def _matches_any_regex(
         ]
     else:
         normalized_values = [_normalize(value) for value in values if _exists(value)]
-    return any(
-        regex.search(value) for regex in compiled for value in normalized_values
-    )
+    return any(regex.search(value) for regex in compiled for value in normalized_values)
 
 
 def _path_basename(path: str | None) -> str | None:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -44,6 +44,10 @@ worker, or deletion behavior.
 - Backend: `ruff check .` and `ruff format .`
 - Frontend: `npm run format` and `npm run check`
 
+CI runs `ruff check` and `ruff format --check`, so run `ruff format .` (not just
+`ruff check`) before pushing. Use `ruff format --check .` to verify formatting the
+same way CI does, without modifying files.
+
 ## Desktop
 
 - To run desktop in development use `uv run --extra desktop python -m desktop`

--- a/docs/usage/rules.md
+++ b/docs/usage/rules.md
@@ -111,6 +111,29 @@ For example, `contains chart` matches a tag such as `weekly-chart-2024`, and
 several fragments at once, combine `contains` conditions with an AND group. A
 blank term matches nothing.
 
+### Regex Operators (Arr tags)
+
+The Arr tags field also matches tags with regular expressions. Each operator
+takes one or more patterns; a pattern is applied with `re.search` and is
+case-insensitive, so anchor with `^` and `$` to match a whole tag. Patterns
+within one operator combine with the same any/none behavior as the list
+operators.
+
+| Internal operator       | UI label             | Meaning                              |
+| ----------------------- | -------------------- | ------------------------------------ |
+| `matches_any_regex`     | matches regex        | Some tag matches one of the patterns |
+| `not_matches_any_regex` | does not match regex | No tag matches any of the patterns   |
+
+`matches_any_regex` is also available on the path fields. A condition with no
+valid pattern matches nothing, so `not_matches_any_regex` never matches an item
+on an empty or invalid pattern.
+
+For example, given tags that pair a base name with a `-stale` variant (such as
+`tag-1` and `tag-1-stale`), an AND group of `matches_any_regex` `tag-.*-stale$`
+and `not_matches_any_regex` `^tag-.*(?<!-stale)$` selects items that carry a
+`-stale` variant but no active base tag. An item still active under any tag keeps
+a value matching the second pattern, so it is excluded.
+
 ### Missing Values
 
 `exists` matches populated metadata. `does not exist` matches missing or empty

--- a/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
+++ b/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
@@ -177,6 +177,7 @@
     is_true: "is true",
     is_false: "is false",
     matches_any_regex: "matches regex",
+    not_matches_any_regex: "does not match regex",
   };
 
   const listOperators = new Set<RuleConditionOperator>([
@@ -189,6 +190,7 @@
     "contains_substring",
     "not_contains_substring",
     "matches_any_regex",
+    "not_matches_any_regex",
   ]);
 
   const valuelessOperators = new Set<RuleConditionOperator>([
@@ -235,6 +237,8 @@
     ...multiValueTextOperators,
     "contains_substring",
     "not_contains_substring",
+    "matches_any_regex",
+    "not_matches_any_regex",
   ];
 
   const libraryOperators: RuleConditionOperator[] = [
@@ -1557,7 +1561,11 @@
     fieldConfig(c.field).kind === "temporal" &&
     !valuelessOperators.has(c.operator);
   const valuePlaceholder = (c: RuleCondition) => {
-    if (c.operator === "matches_any_regex") return "regex patterns…";
+    if (
+      c.operator === "matches_any_regex" ||
+      c.operator === "not_matches_any_regex"
+    )
+      return "regex patterns…";
     if (c.field === "seerr.requested_by_user_ids")
       return "Seerr user IDs (comma-separated)...";
     if (c.field === "playback.usernames")

--- a/frontend/src/lib/types/shared.ts
+++ b/frontend/src/lib/types/shared.ts
@@ -405,7 +405,8 @@ export type RuleConditionOperator =
   | "not_exists"
   | "is_true"
   | "is_false"
-  | "matches_any_regex";
+  | "matches_any_regex"
+  | "not_matches_any_regex";
 
 export interface RuleCondition {
   type: "condition";

--- a/tests/test_cleanup_media_rules.py
+++ b/tests/test_cleanup_media_rules.py
@@ -1833,6 +1833,41 @@ class CleanupMediaRuleTests(unittest.TestCase):
         self.assertFalse(_evaluate_movie_rule(untagged, rule, {}, []))
         self.assertFalse(_evaluate_movie_rule(other_tag, rule, {}, []))
 
+    def test_evaluate_rule_matches_stale_but_not_active_tags(self) -> None:
+        rule = _make_multi_condition_rule(
+            name="stale-not-active",
+            media_type=MediaType.SERIES,
+            target_scope="series",
+            conditions=[
+                {
+                    "type": "condition",
+                    "field": "arr.tags",
+                    "operator": "matches_any_regex",
+                    "value": ["tag-.*-stale$"],
+                },
+                {
+                    "type": "condition",
+                    "field": "arr.tags",
+                    "operator": "not_matches_any_regex",
+                    "value": ["^tag-.*(?<!-stale)$"],
+                },
+            ],
+        )
+
+        stale_only = Series(title="Stale Only", tmdb_id=901, size=20 * 1024**3)
+        stale_only.arr_tags = ["tag-1-stale"]
+        mixed = Series(title="Mixed", tmdb_id=902, size=20 * 1024**3)
+        mixed.arr_tags = ["tag-1-stale", "tag-2"]
+        active_only = Series(title="Active Only", tmdb_id=903, size=20 * 1024**3)
+        active_only.arr_tags = ["tag-2"]
+        untagged = Series(title="Untagged", tmdb_id=904, size=20 * 1024**3)
+        untagged.arr_tags = []
+
+        self.assertTrue(_evaluate_movie_rule(stale_only, rule, {}, []))
+        self.assertFalse(_evaluate_movie_rule(mixed, rule, {}, []))
+        self.assertFalse(_evaluate_movie_rule(active_only, rule, {}, []))
+        self.assertFalse(_evaluate_movie_rule(untagged, rule, {}, []))
+
     def test_evaluate_series_rule_days_since_air_dates_passes_and_fails(self) -> None:
         now = datetime.now(UTC)
         series = Series(title="Series", tmdb_id=2, size=20 * 1024**3)

--- a/tests/test_rule_engine_validation.py
+++ b/tests/test_rule_engine_validation.py
@@ -827,6 +827,30 @@ class ArrTagRegexOperatorTests(unittest.TestCase):
             )
         )
 
+    def test_matches_any_regex_empty_string_pattern_fails_closed(self) -> None:
+        self.assertFalse(
+            _matches_operator(
+                ["tag-1-stale"], "matches_any_regex", [""], field="arr.tags"
+            )
+        )
+
+    def test_not_matches_any_regex_empty_string_pattern_fails_closed(self) -> None:
+        self.assertFalse(
+            _matches_operator(
+                ["tag-1-stale", "tag-2"],
+                "not_matches_any_regex",
+                [""],
+                field="arr.tags",
+            )
+        )
+
+    def test_matches_any_regex_invalid_pattern_fails_closed(self) -> None:
+        self.assertFalse(
+            _matches_operator(
+                ["tag-1-stale"], "matches_any_regex", ["[invalid"], field="arr.tags"
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rule_engine_validation.py
+++ b/tests/test_rule_engine_validation.py
@@ -309,6 +309,20 @@ class RuleDefinitionValidationTests(unittest.TestCase):
             _definition("media.path", "matches_any_regex", [r"movies/.+\\.mkv"]),
         )
 
+    def test_accepts_tag_regex_operators(self) -> None:
+        validate_rule_definition(
+            _definition("arr.tags", "matches_any_regex", ["tag-.*-stale$"]),
+        )
+        validate_rule_definition(
+            _definition("arr.tags", "not_matches_any_regex", ["^tag-.*(?<!-stale)$"]),
+        )
+
+    def test_rejects_tag_regex_operator_on_non_tag_field(self) -> None:
+        with self.assertRaises(ValueError):
+            validate_rule_definition(
+                _definition("media.title", "not_matches_any_regex", ["x"]),
+            )
+
     def test_rejects_boolean_field_with_numeric_operator(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
@@ -740,6 +754,78 @@ class ArrTagSubstringOperatorTests(unittest.TestCase):
                 _definition("tmdb.genres", "contains_substring", "chart"),
                 target_scope=TARGET_MOVIE_VERSION,
             )
+
+
+class ArrTagRegexOperatorTests(unittest.TestCase):
+    def test_matches_any_regex_matches_tag(self) -> None:
+        tags = ["tag-1-stale", "tag-2"]
+        self.assertTrue(
+            _matches_operator(
+                tags, "matches_any_regex", ["tag-.*-stale$"], field="arr.tags"
+            )
+        )
+
+    def test_matches_any_regex_is_case_insensitive(self) -> None:
+        tags = ["TAG-1-STALE"]
+        self.assertTrue(
+            _matches_operator(
+                tags, "matches_any_regex", ["tag-.*-stale$"], field="arr.tags"
+            )
+        )
+
+    def test_matches_any_regex_multiple_patterns_or(self) -> None:
+        tags = ["tag-2"]
+        self.assertTrue(
+            _matches_operator(
+                tags, "matches_any_regex", ["nope", "^tag-2$"], field="arr.tags"
+            )
+        )
+
+    def test_matches_any_regex_no_match(self) -> None:
+        tags = ["tag-2"]
+        self.assertFalse(
+            _matches_operator(
+                tags, "matches_any_regex", ["tag-.*-stale$"], field="arr.tags"
+            )
+        )
+
+    def test_matches_any_regex_empty_patterns_fails_closed(self) -> None:
+        self.assertFalse(
+            _matches_operator(
+                ["tag-1-stale"], "matches_any_regex", [], field="arr.tags"
+            )
+        )
+
+    def test_not_matches_any_regex_true_when_no_active_tag(self) -> None:
+        tags = ["tag-1-stale"]
+        self.assertTrue(
+            _matches_operator(
+                tags, "not_matches_any_regex", ["^tag-.*(?<!-stale)$"], field="arr.tags"
+            )
+        )
+
+    def test_not_matches_any_regex_false_when_active_tag_present(self) -> None:
+        tags = ["tag-1-stale", "tag-2"]
+        self.assertFalse(
+            _matches_operator(
+                tags, "not_matches_any_regex", ["^tag-.*(?<!-stale)$"], field="arr.tags"
+            )
+        )
+
+    def test_not_matches_any_regex_empty_patterns_fails_closed(self) -> None:
+        # A condition with no valid pattern must not match everything.
+        self.assertFalse(
+            _matches_operator(
+                ["tag-1-stale", "tag-2"], "not_matches_any_regex", [], field="arr.tags"
+            )
+        )
+
+    def test_not_matches_any_regex_invalid_pattern_fails_closed(self) -> None:
+        self.assertFalse(
+            _matches_operator(
+                ["tag-1-stale"], "not_matches_any_regex", ["[invalid"], field="arr.tags"
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_rules_path_validation.py
+++ b/tests/test_rules_path_validation.py
@@ -285,6 +285,73 @@ def test_create_rule_skips_existence_checks_for_path_negation_operator() -> None
     asyncio.run(run())
 
 
+def test_create_rule_rejects_invalid_tag_regex() -> None:
+    async def run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        session_maker = async_sessionmaker(
+            engine, expire_on_commit=False, class_=AsyncSession
+        )
+
+        async with session_maker() as db:
+            admin = _admin_user()
+            db.add(admin)
+            await db.commit()
+
+            payload = CleanupRuleCreate(
+                name="bad-tag-regex",
+                media_type=MediaType.MOVIE,
+                enabled=True,
+                target_scope="movie_version",
+                definition=_definition("arr.tags", "matches_any_regex", ["[invalid"]),
+                action=None,
+            )
+
+            with pytest.raises(HTTPException) as exc:
+                await create_rule(payload, admin, db)
+
+            assert exc.value.status_code == 400
+            assert "Invalid regex pattern" in str(exc.value.detail)
+
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_create_rule_accepts_valid_tag_regex() -> None:
+    async def run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        session_maker = async_sessionmaker(
+            engine, expire_on_commit=False, class_=AsyncSession
+        )
+
+        async with session_maker() as db:
+            admin = _admin_user()
+            db.add(admin)
+            await db.commit()
+
+            payload = CleanupRuleCreate(
+                name="good-tag-regex",
+                media_type=MediaType.MOVIE,
+                enabled=True,
+                target_scope="movie_version",
+                definition=_definition(
+                    "arr.tags", "not_matches_any_regex", ["^tag-.*(?<!-stale)$"]
+                ),
+                action=None,
+            )
+
+            # Should not raise.
+            await create_rule(payload, admin, db)
+
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
 def test_validate_paths_endpoint_supports_structured_and_legacy_payloads() -> None:
     async def run() -> None:
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)


### PR DESCRIPTION
## Summary

Adds two operators to the `arr.tags` rule field so a rule can match tags with a regular expression:

- `matches_any_regex` (UI: "matches regex") — matches when any tag matches any supplied pattern.
- `not_matches_any_regex` (UI: "does not match regex") — matches when no tag matches any supplied pattern.

`matches_any_regex` already existed for the path fields; this enables it for `arr.tags` and adds the negated form. Both compose with the existing AND/OR rule groups. Matching is case-insensitive and uses `re.search`, so anchor with `^`/`$` to match a whole tag.

## Motivation

Tag matching currently supports whole-tag operators and substring operators. Neither can distinguish a base tag from a suffixed variant that shares its prefix (for example `tag-1` vs `tag-1-stale`), because the base string is a substring of the variant and substrings have no anchoring. Selecting "items that have a variant but none of the base tags" also needs a negated pattern operator, which did not exist for tags. Regex with anchoring plus a negated operator covers both.

Example — select items that carry a `-stale` variant but no active base tag:

- `arr.tags matches_any_regex ["tag-.*-stale$"]` (has a stale variant), AND
- `arr.tags not_matches_any_regex ["^tag-.*(?<!-stale)$"]` (has no active base tag)

An item still active under any tag keeps a value matching the second pattern, so it is excluded.

## Changes

- Rule engine: enable both operators on `arr.tags`; make the regex matcher field-aware (tags use plain string normalization, path fields keep path normalization); fail closed (no match for both operators) when a condition has no valid pattern, including empty or blank patterns.
- API: reject syntactically invalid tag patterns at save time with HTTP 400 (create, update, preview, import), reusing the existing invalid-pattern error. Tags get the syntax check only, not the path live-match check.
- Frontend: both operators are selectable on the Arr tags field with a multi-value pattern input.
- Docs and CHANGELOG updated.

## Testing

- New unit tests for both operators (positive, negated, multi-pattern, case-insensitivity, anchored patterns, and fail-closed on empty/invalid/blank patterns), a validation-acceptance test, an API 400 rejection test, and an end-to-end AND-group scenario.
- Full backend suite: 469 passed. Frontend `svelte-check`: 0 errors, 0 warnings.
