### PR TITLE
fix: soft-delete and dedup correctness in the media sync

### DIFF
--- a/backend/api/routes/protected.py
+++ b/backend/api/routes/protected.py
@@ -242,6 +242,16 @@ async def get_protected_entries(
         .outerjoin(ReclaimRule, ReclaimRule.id == ProtectedMedia.source_rule_id)
     )
 
+    # manual protections survive a soft-delete of their media, so a protected
+    # entry can outlive the row it points at. Hide those from both the page and
+    # its count, or the two disagree.
+    live_media_filter = (
+        or_(ProtectedMedia.movie_id.is_(None), Movie.removed_at.is_(None)),
+        or_(ProtectedMedia.series_id.is_(None), Series.removed_at.is_(None)),
+    )
+    base_query = base_query.where(*live_media_filter)
+    count_query = count_query.where(*live_media_filter)
+
     if media_type:
         count_query = count_query.where(ProtectedMedia.media_type == media_type)
 

--- a/backend/api/routes/requests.py
+++ b/backend/api/routes/requests.py
@@ -590,6 +590,31 @@ async def create_protection_request(
     )
 
 
+def _live_media_filters() -> list[ColumnElement[bool]]:
+    """Restrict a ProtectionRequest query to requests whose media still exists.
+
+    Protection requests now outlive a soft-delete of their media, so a request
+    can point at a tombstone. The medium is still loadable, so the relationship
+    resolves and the request renders normally, for a title that appears nowhere
+    else in the app. These queries have no joins, so membership is expressed as
+    a subquery, matching the protected lists.
+    """
+    return [
+        or_(
+            ProtectionRequest.movie_id.is_(None),
+            ProtectionRequest.movie_id.in_(
+                select(Movie.id).where(Movie.removed_at.is_(None))
+            ),
+        ),
+        or_(
+            ProtectionRequest.series_id.is_(None),
+            ProtectionRequest.series_id.in_(
+                select(Series.id).where(Series.removed_at.is_(None))
+            ),
+        ),
+    ]
+
+
 @router.get("/protection-requests/my", response_model=list[ProtectionRequestResponse])
 async def get_my_requests(
     user: Annotated[User, Depends(require_page_access(PageAccess.REQUESTS))],
@@ -600,6 +625,7 @@ async def get_my_requests(
     query = (
         select(ProtectionRequest)
         .where(ProtectionRequest.requested_by_user_id == user.id)
+        .where(*_live_media_filters())
         .options(
             selectinload(ProtectionRequest.movie),
             selectinload(ProtectionRequest.series),
@@ -671,13 +697,17 @@ async def get_all_requests(
     status_filter: ProtectionRequestStatus | None = Query(None),
 ) -> list[ProtectionRequestResponse]:
     """Get all exception requests (manage-requests permission)."""
-    query = select(ProtectionRequest).options(
-        selectinload(ProtectionRequest.movie),
-        selectinload(ProtectionRequest.series),
-        selectinload(ProtectionRequest.season),
-        selectinload(ProtectionRequest.episode),
-        selectinload(ProtectionRequest.requested_by),
-        selectinload(ProtectionRequest.reviewed_by),
+    query = (
+        select(ProtectionRequest)
+        .where(*_live_media_filters())
+        .options(
+            selectinload(ProtectionRequest.movie),
+            selectinload(ProtectionRequest.series),
+            selectinload(ProtectionRequest.season),
+            selectinload(ProtectionRequest.episode),
+            selectinload(ProtectionRequest.requested_by),
+            selectinload(ProtectionRequest.reviewed_by),
+        )
     )
 
     if status_filter:
@@ -762,10 +792,15 @@ async def approve_request(
             detail=f"Request has already been {request.status.value}",
         )
 
-    # get media
+    # get media. Soft-deleted media is treated as absent here, the same way
+    # create_request treats it: approving would add a protection that both
+    # protected lists then filter out, so the requester would be told it worked
+    # while nothing appeared anywhere.
     if request.media_type is MediaType.MOVIE:
         media_result = await db.execute(
-            select(Movie).where(Movie.id == request.movie_id)
+            select(Movie).where(
+                Movie.id == request.movie_id, Movie.removed_at.is_(None)
+            )
         )
         media = media_result.scalar_one_or_none()
         if media is None:
@@ -774,7 +809,9 @@ async def approve_request(
             )
     else:
         media_result = await db.execute(
-            select(Series).where(Series.id == request.series_id)
+            select(Series).where(
+                Series.id == request.series_id, Series.removed_at.is_(None)
+            )
         )
         media = media_result.scalar_one_or_none()
         if media is None:

--- a/backend/api/routes/v1/protections.py
+++ b/backend/api/routes/v1/protections.py
@@ -241,6 +241,25 @@ async def list_protections(
         )
     if active_only:
         filters.append(_active_filter(datetime.now(UTC)))
+    # manual protections outlive a soft-delete of their media; exclude any whose
+    # movie or series is currently tombstoned. This query has no joins, so the
+    # membership test is expressed as a subquery.
+    filters.append(
+        or_(
+            ProtectedMedia.movie_id.is_(None),
+            ProtectedMedia.movie_id.in_(
+                select(Movie.id).where(Movie.removed_at.is_(None))
+            ),
+        )
+    )
+    filters.append(
+        or_(
+            ProtectedMedia.series_id.is_(None),
+            ProtectedMedia.series_id.in_(
+                select(Series.id).where(Series.removed_at.is_(None))
+            ),
+        )
+    )
     total = int(
         (
             await db.execute(

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -1801,6 +1801,10 @@ async def sync_series(
 
             # track all tmdb_ids seen in this sync
             parsed_tmdb_ids = set[int]()
+            # row primary keys touched this run. parsed_tmdb_ids cannot serve
+            # this purpose: a row matched by the tvdb/imdb fallback keeps its
+            # own tmdb_id, which is not the id that was just parsed.
+            matched_row_ids: set[int] = set()
 
             # iterate through aggregated series
             batch_count = 0
@@ -1821,6 +1825,18 @@ async def sync_series(
 
                 # if series already exists, update it
                 if existing_series_obj is not None:
+                    if existing_series_obj.id in matched_row_ids:
+                        # two incoming series resolved to one row. only one of
+                        # them can be represented while tmdb_id is unique, so
+                        # the other is silently unreachable without this line.
+                        LOG.warning(
+                            f"Series '{series.name}' resolved to a database row "
+                            f"already claimed by another series in this sync "
+                            f"(row {existing_series_obj.id}, "
+                            f"tmdb {existing_series_obj.tmdb_id}). Only one can "
+                            f"be stored; this one will not appear in Reclaimerr."
+                        )
+                    matched_row_ids.add(existing_series_obj.id)
                     # always update watch data, size, and file info from media server
                     existing_series_obj.size = series.size
                     media_rollup = _rollup_series_media_from_seasons(series.season_data)
@@ -2163,11 +2179,21 @@ async def sync_series(
                 await session.commit()
 
             if allow_soft_delete:
-                series_to_delete = [
-                    s
-                    for s in existing_series.values()
-                    if s.tmdb_id not in parsed_tmdb_ids and not s.removed_at
-                ]
+                series_to_delete = _select_rows_to_soft_delete(
+                    existing_series_list, matched_row_ids
+                )
+                live_series_count = sum(
+                    1 for s in existing_series_list if not s.removed_at
+                )
+                if _soft_delete_guard_tripped(len(series_to_delete), live_series_count):
+                    LOG.warning(
+                        f"Skipping series soft-delete: {len(series_to_delete)} of "
+                        f"{live_series_count} live series would be removed, which "
+                        f"suggests a partial response from {source_label} rather "
+                        f"than real deletions. Deletions will run on the next "
+                        f"healthy sync."
+                    )
+                    series_to_delete = []
 
                 if series_to_delete:
                     LOG.info(

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -126,23 +126,26 @@ async def _apply_soft_deletes(
     if media_type is MediaType.MOVIE:
         candidate_col = ReclaimCandidate.movie_id
         protected_col = ProtectedMedia.movie_id
-        request_col = ProtectionRequest.movie_id
     else:
         candidate_col = ReclaimCandidate.series_id
         protected_col = ProtectedMedia.series_id
-        request_col = ProtectionRequest.series_id
 
+    # Delete only what the system can rebuild. Candidates come from the reclaim
+    # scan and rule-sourced protections from the rule task, so both regenerate.
+    # Manual protections and protection requests are user intent that nothing can
+    # reconstruct, and the medium itself is only soft-deleted, so they stay and are
+    # still attached if the row is restored.
     await session.execute(
         sql_delete(ReclaimCandidate).where(candidate_col.in_(deleted_ids))
     )
     await session.execute(
-        sql_delete(ProtectedMedia).where(protected_col.in_(deleted_ids))
-    )
-    await session.execute(
-        sql_delete(ProtectionRequest).where(request_col.in_(deleted_ids))
+        sql_delete(ProtectedMedia).where(
+            protected_col.in_(deleted_ids),
+            ProtectedMedia.source == "rule",
+        )
     )
     LOG.debug(
-        f"Cleaned up candidates and protection entries for {len(deleted_ids)} "
+        f"Cleaned up candidates and rule protections for {len(deleted_ids)} "
         f"soft-deleted {media_type.value} rows"
     )
     return deleted_ids

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -1,7 +1,8 @@
 import asyncio
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
-from typing import Any, TypeGuard
+from typing import Any, TypeGuard, TypeVar
 
 from sqlalchemy import delete as sql_delete
 from sqlalchemy import select
@@ -65,6 +66,86 @@ __all__ = [
 # number of records to process before committing to the database during sync tasks
 COMMIT_BATCH_SIZE = 100
 SONARR_DATE_FETCH_CONCURRENCY = 5
+# refuse to tombstone more than half the library in one pass - a partial
+# media-server response should not look like a mass deletion
+MAX_SOFT_DELETE_RATIO = 0.5
+MIN_LIBRARY_FOR_RATIO_CHECK = 20
+
+_RowT = TypeVar("_RowT", Movie, Series)
+
+
+def _select_rows_to_soft_delete(
+    rows: Sequence[_RowT],
+    matched_row_ids: set[int],
+) -> list[_RowT]:
+    """Rows this sync did not touch, and that are not already tombstoned.
+
+    Identity here is the row primary key, not the TMDB id. A row can be matched
+    through the tvdb/imdb fallback while keeping a different tmdb_id, so testing
+    the tmdb_id would tombstone a row that was just updated from the main server.
+    """
+    return [row for row in rows if row.id not in matched_row_ids and not row.removed_at]
+
+
+def _soft_delete_guard_tripped(delete_count: int, live_count: int) -> bool:
+    """True when a delete set is too large a share of the library to trust.
+
+    A partial media-server response makes the incoming set look small, and
+    everything missing from it look deleted. Small libraries are exempt: removing
+    three of four items there is legitimate.
+    """
+    if live_count < MIN_LIBRARY_FOR_RATIO_CHECK:
+        return False
+    return delete_count > live_count * MAX_SOFT_DELETE_RATIO
+
+
+async def _apply_soft_deletes(
+    session: AsyncSession,
+    rows: Sequence[_RowT],
+    media_type: MediaType,
+) -> list[int]:
+    """Tombstone rows and remove the derived rows hanging off them.
+
+    The medium itself is kept so its metadata can be reused if it reappears;
+    only `removed_at` marks it gone. Does not commit - the caller decides when.
+
+    Returns the tombstoned row ids.
+    """
+    if not rows:
+        return []
+
+    now = datetime.now(UTC)
+    deleted_ids: list[int] = []
+    for row in rows:
+        row.removed_at = now
+        row.added_at = None
+        row.arr_added_at = None
+        deleted_ids.append(row.id)
+        LOG.debug(f"Soft-deleted: {row.title} ({row.tmdb_id})")
+
+    if media_type is MediaType.MOVIE:
+        candidate_col = ReclaimCandidate.movie_id
+        protected_col = ProtectedMedia.movie_id
+        request_col = ProtectionRequest.movie_id
+    else:
+        candidate_col = ReclaimCandidate.series_id
+        protected_col = ProtectedMedia.series_id
+        request_col = ProtectionRequest.series_id
+
+    await session.execute(
+        sql_delete(ReclaimCandidate).where(candidate_col.in_(deleted_ids))
+    )
+    await session.execute(
+        sql_delete(ProtectedMedia).where(protected_col.in_(deleted_ids))
+    )
+    await session.execute(
+        sql_delete(ProtectionRequest).where(request_col.in_(deleted_ids))
+    )
+    LOG.debug(
+        f"Cleaned up candidates and protection entries for {len(deleted_ids)} "
+        f"soft-deleted {media_type.value} rows"
+    )
+    return deleted_ids
 
 
 def _is_media_server_type(service: Service) -> TypeGuard[MediaServerType]:
@@ -1585,38 +1666,9 @@ async def sync_movies(
                     LOG.info(
                         f"Soft-deleting {len(movies_to_delete)} movies no longer in {effective_service.value}"
                     )
-                    deleted_movie_ids = []
-                    for db_movie_to_delete in movies_to_delete:
-                        db_movie_to_delete.removed_at = datetime.now(UTC)
-                        db_movie_to_delete.added_at = None
-                        db_movie_to_delete.arr_added_at = None
-                        deleted_movie_ids.append(db_movie_to_delete.id)
-                        LOG.debug(
-                            f"Soft-deleted: {db_movie_to_delete.title} "
-                            f"({db_movie_to_delete.tmdb_id})"
-                        )
-
-                    # clean up orphaned candidates and protection entries
-                    if deleted_movie_ids:
-                        await session.execute(
-                            sql_delete(ReclaimCandidate).where(
-                                ReclaimCandidate.movie_id.in_(deleted_movie_ids)
-                            )
-                        )
-                        await session.execute(
-                            sql_delete(ProtectedMedia).where(
-                                ProtectedMedia.movie_id.in_(deleted_movie_ids)
-                            )
-                        )
-                        await session.execute(
-                            sql_delete(ProtectionRequest).where(
-                                ProtectionRequest.movie_id.in_(deleted_movie_ids)
-                            )
-                        )
-                        LOG.debug(
-                            f"Cleaned up candidates/protection entries for {len(deleted_movie_ids)} soft-deleted movies"
-                        )
-
+                    await _apply_soft_deletes(
+                        session, movies_to_delete, MediaType.MOVIE
+                    )
                     await session.commit()
 
             duration = (datetime.now(UTC) - start_time).total_seconds()
@@ -2105,35 +2157,9 @@ async def sync_series(
                     LOG.info(
                         f"Soft-deleting {len(series_to_delete)} series no longer in {source_label}"
                     )
-                    deleted_series_ids = []
-                    for s in series_to_delete:
-                        s.removed_at = datetime.now(UTC)
-                        s.added_at = None
-                        s.arr_added_at = None
-                        deleted_series_ids.append(s.id)
-                        LOG.debug(f"Soft-deleted: {s.title} ({s.tmdb_id})")
-
-                    # clean up orphaned candidates and protection entries
-                    if deleted_series_ids:
-                        await session.execute(
-                            sql_delete(ReclaimCandidate).where(
-                                ReclaimCandidate.series_id.in_(deleted_series_ids)
-                            )
-                        )
-                        await session.execute(
-                            sql_delete(ProtectedMedia).where(
-                                ProtectedMedia.series_id.in_(deleted_series_ids)
-                            )
-                        )
-                        await session.execute(
-                            sql_delete(ProtectionRequest).where(
-                                ProtectionRequest.series_id.in_(deleted_series_ids)
-                            )
-                        )
-                        LOG.debug(
-                            f"Cleaned up candidates/protection entries for {len(deleted_series_ids)} soft-deleted series"
-                        )
-
+                    await _apply_soft_deletes(
+                        session, series_to_delete, MediaType.SERIES
+                    )
                     await session.commit()
 
             duration = (datetime.now(UTC) - start_time).total_seconds()

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -1291,13 +1291,19 @@ def _dedupe_aggregated_series(
 ) -> tuple[dict[int, AggregatedSeriesData], _SupplementalEpisodeData]:
     """Reduce gathered series to one entry per TMDB id.
 
-    Two cases share this code path and must not be confused. The same series
-    reported by two services is a duplicate: keep one and stash the loser's
-    season data as supplemental so its episode ids still reach the episodes
-    table. Two different series that share a TMDB id, which happens where TMDB
-    carries an umbrella entry, are not duplicates: merging them would write the
-    loser's episode ids onto the winner's episode rows. Distinct tvdb ids on
-    both sides are what tells them apart.
+    Two cases share this code path and must not be confused. One series
+    reported more than once from the same server, typically because it sits in
+    two libraries, is a duplicate: keep one and stash the loser's season data as
+    supplemental so its service-specific episode ids (plex_rating_key,
+    jellyfin_episode_id, emby_episode_id) still reach the episodes table. Two
+    different series that share a TMDB id, which happens where TMDB carries an
+    umbrella entry, are not duplicates: merging them would write the loser's
+    episode ids onto the winner's episode rows. Distinct tvdb ids on both sides
+    are what tells them apart.
+
+    The merge branch also covers one series reported by two services, but
+    sync_series is the only caller of gather_series and always passes a single
+    resolved service, so that no longer arises from a gather.
     """
     unique_series: dict[int, AggregatedSeriesData] = {}
     supplemental: _SupplementalEpisodeData = {}
@@ -1862,9 +1868,11 @@ async def sync_series(
 ) -> set[int]:
     """Sync series from the main media server (or a specific service).
 
-    Mirrors sync_movies: a linked (non-main) server contributes watch data via
-    sync_linked_data, never series rows, and no argument means the main server
-    rather than every configured server.
+    Mirrors sync_movies: a linked (non-main) server contributes watch data
+    rather than series rows, and no argument means the main server rather than
+    every configured server. That watch data comes from sync_linked_data, which
+    sync_media calls in its own loop over the linked servers; unlike sync_movies
+    this function does not call it, it only declines to sync the linked server.
     """
     # resolve main server
     async with async_db() as _cfg:
@@ -2078,11 +2086,11 @@ async def sync_series(
             )
 
             #### supplemental episode ID pass ####
-            # For series that appeared in multiple services (e.g. Plex + Jellyfin/Emby),
-            # the losing service's episode data was discarded during deduplication.
-            # We re-run _upsert_episodes for those seasons here so that all
-            # service specific IDs (plex_rating_key, jellyfin_episode_id, etc.)
-            # are written to the episodes table
+            # For series reported more than once by the gather, the losing
+            # entry's episode data was discarded during deduplication. We re-run
+            # _upsert_episodes for those seasons here so that all service
+            # specific IDs (plex_rating_key, jellyfin_episode_id,
+            # emby_episode_id) are written to the episodes table
             if supplemental_episode_data:
                 LOG.debug(
                     f"Running supplemental episode ID upsert for "

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -99,6 +99,40 @@ def _soft_delete_guard_tripped(delete_count: int, live_count: int) -> bool:
     return delete_count > live_count * MAX_SOFT_DELETE_RATIO
 
 
+# A delete set larger than the ratio allows is usually a partial media-server
+# response, but it is also what a legitimate main-server switch looks like. A
+# flapping server proposes a DIFFERENT set each time; a real reduction proposes
+# the same one. So skip the first time and act if the same set comes back.
+_previous_large_delete_sets: dict[MediaType, frozenset[int]] = {}
+
+
+def _soft_delete_blocked(
+    media_type: MediaType,
+    rows_to_delete: Sequence[_RowT],
+    live_count: int,
+) -> bool:
+    """True when this delete set should be skipped this run.
+
+    Blocking on the ratio alone deadlocks: a main-server switch proposes the
+    same large set every run, and the phantom rows it wants gone inflate the
+    live count faster than the real library grows, so the pass never relents.
+    Remembering the previous over-ratio set turns the guard into one grace run
+    rather than a permanent block.
+
+    The memory is process-local by design; a restart just costs one more grace
+    run, which is not worth persisting for.
+    """
+    if not _soft_delete_guard_tripped(len(rows_to_delete), live_count):
+        _previous_large_delete_sets.pop(media_type, None)
+        return False
+    signature = frozenset(row.id for row in rows_to_delete)
+    if _previous_large_delete_sets.get(media_type) == signature:
+        _previous_large_delete_sets.pop(media_type, None)
+        return False
+    _previous_large_delete_sets[media_type] = signature
+    return True
+
+
 def _tvdb_sorts_first(a: str, b: str) -> bool:
     """True when tvdb id `a` orders before `b`.
 
@@ -1722,13 +1756,16 @@ async def sync_movies(
                 live_movie_count = sum(
                     1 for movie in existing_movies_list if not movie.removed_at
                 )
-                if _soft_delete_guard_tripped(len(movies_to_delete), live_movie_count):
+                if _soft_delete_blocked(
+                    MediaType.MOVIE, movies_to_delete, live_movie_count
+                ):
                     LOG.warning(
-                        f"Skipping movie soft-delete: {len(movies_to_delete)} of "
-                        f"{live_movie_count} live movies would be removed, which "
-                        f"suggests a partial response from "
-                        f"{effective_service.value} rather than real deletions. "
-                        f"Deletions will run on the next healthy sync."
+                        f"Skipping movie soft-delete this run: "
+                        f"{len(movies_to_delete)} of {live_movie_count} live movies "
+                        f"would be removed, which may be a partial response from "
+                        f"{effective_service.value} rather than real deletions. If "
+                        f"the next sync proposes the same movies they will be "
+                        f"removed then."
                     )
                     movies_to_delete = []
 
@@ -2265,13 +2302,15 @@ async def sync_series(
                 live_series_count = sum(
                     1 for s in existing_series_list if not s.removed_at
                 )
-                if _soft_delete_guard_tripped(len(series_to_delete), live_series_count):
+                if _soft_delete_blocked(
+                    MediaType.SERIES, series_to_delete, live_series_count
+                ):
                     LOG.warning(
-                        f"Skipping series soft-delete: {len(series_to_delete)} of "
-                        f"{live_series_count} live series would be removed, which "
-                        f"suggests a partial response from {source_label} rather "
-                        f"than real deletions. Deletions will run on the next "
-                        f"healthy sync."
+                        f"Skipping series soft-delete this run: "
+                        f"{len(series_to_delete)} of {live_series_count} live series "
+                        f"would be removed, which may be a partial response from "
+                        f"{source_label} rather than real deletions. If the next "
+                        f"sync proposes the same series they will be removed then."
                     )
                     series_to_delete = []
 

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -1769,12 +1769,38 @@ async def sync_series(
     service: MediaServerType | None = None,
     allow_soft_delete: bool = True,
 ) -> set[int]:
-    """Sync series from media servers to database."""
+    """Sync series from the main media server (or a specific service).
+
+    Mirrors sync_movies: a linked (non-main) server contributes watch data via
+    sync_linked_data, never series rows, and no argument means the main server
+    rather than every configured server.
+    """
+    # resolve main server
+    async with async_db() as _cfg:
+        main_server = await _get_main_media_server(_cfg)
+    main_service_type: MediaServerType | None = (
+        main_server.service_type if main_server else None  # type: ignore[assignment]
+    )
+
+    # a linked server never contributes series rows
+    if (
+        service is not None
+        and main_service_type is not None
+        and service != main_service_type
+    ):
+        LOG.info(f"{service} is a linked server - skipping series sync")
+        return set()
+
+    effective_service = service or main_service_type
+    if effective_service is None:
+        LOG.error("No main media server configured for series sync")
+        return set()
+
     start_time = datetime.now(UTC)
-    source_label = service.value if service else "all-media-services"
+    source_label = effective_service.value
     LOG.info(f"Starting series sync ({source_label})...")
 
-    gather_result = await gather_series(service)
+    gather_result = await gather_series(effective_service)
     if not gather_result:
         LOG.info(f"No series to sync from {source_label}")
         return set()

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -99,6 +99,18 @@ def _soft_delete_guard_tripped(delete_count: int, live_count: int) -> bool:
     return delete_count > live_count * MAX_SOFT_DELETE_RATIO
 
 
+def _tvdb_sorts_first(a: str, b: str) -> bool:
+    """True when tvdb id `a` orders before `b`.
+
+    Numeric when both are numeric, which they are in practice, so that "9001"
+    sorts before "10001" rather than after it. The ordering only has to be
+    stable, not meaningful.
+    """
+    if a.isdigit() and b.isdigit():
+        return int(a) < int(b)
+    return a < b
+
+
 async def _apply_soft_deletes(
     session: AsyncSession,
     rows: Sequence[_RowT],
@@ -1240,6 +1252,94 @@ async def gather_movies(
 _SupplementalEpisodeData = dict[int, list[tuple[Service, list[AggregatedSeasonData]]]]
 
 
+def _dedupe_aggregated_series(
+    aggregated_series: list[AggregatedSeriesData],
+) -> tuple[dict[int, AggregatedSeriesData], _SupplementalEpisodeData]:
+    """Reduce gathered series to one entry per TMDB id.
+
+    Two cases share this code path and must not be confused. The same series
+    reported by two services is a duplicate: keep one and stash the loser's
+    season data as supplemental so its episode ids still reach the episodes
+    table. Two different series that share a TMDB id, which happens where TMDB
+    carries an umbrella entry, are not duplicates: merging them would write the
+    loser's episode ids onto the winner's episode rows. Distinct tvdb ids on
+    both sides are what tells them apart.
+    """
+    unique_series: dict[int, AggregatedSeriesData] = {}
+    supplemental: _SupplementalEpisodeData = {}
+    skipped_count = 0
+
+    for series in aggregated_series:
+        ext_ids = series.external_ids
+        if not ext_ids or not ext_ids.tmdb:
+            skipped_count += 1
+            continue
+
+        tmdb_id = ext_ids.tmdb
+        if tmdb_id not in unique_series:
+            unique_series[tmdb_id] = series
+            continue
+
+        existing = unique_series[tmdb_id]
+        existing_tvdb = existing.external_ids.tvdb if existing.external_ids else None
+        incoming_tvdb = ext_ids.tvdb
+
+        # genuine collision: two distinct series under one TMDB id
+        if existing_tvdb and incoming_tvdb and existing_tvdb != incoming_tvdb:
+            if _tvdb_sorts_first(existing_tvdb, incoming_tvdb):
+                winner, loser = existing, series
+            else:
+                winner, loser = series, existing
+            LOG.warning(
+                f"TMDB id {tmdb_id} is shared by two distinct series: "
+                f"'{winner.name}' (tvdb {winner.external_ids.tvdb}) and "
+                f"'{loser.name}' (tvdb {loser.external_ids.tvdb}). Only one can be "
+                f"stored, so '{loser.name}' will not appear in Reclaimerr. Its "
+                f"episode data is discarded rather than merged, which would "
+                f"otherwise attach it to the wrong series."
+            )
+            if winner is series:
+                # the displaced incumbent may have already stashed supplemental
+                # under this tmdb id from an earlier cross-service merge - that
+                # data belongs to the incumbent, not the winner, so drop it here
+                # or it grafts onto the winner's episode rows instead
+                supplemental.pop(tmdb_id, None)
+            unique_series[tmdb_id] = winner
+            continue
+
+        # keep series with most recent watch date
+        if series.last_viewed_at and (
+            not existing.last_viewed_at
+            or series.last_viewed_at > existing.last_viewed_at
+        ):
+            # existing loses - stash its season data as supplemental
+            supplemental.setdefault(tmdb_id, []).append(
+                (existing.service, existing.season_data)
+            )
+            unique_series[tmdb_id] = series
+        else:
+            # new series loses - stash its season data as supplemental
+            # (covers both the equal-date case and the "existing wins" case)
+            if series.last_viewed_at == existing.last_viewed_at:
+                if series.added_at and (
+                    not existing.added_at or series.added_at > existing.added_at
+                ):
+                    # new series wins on added_at - existing loses
+                    supplemental.setdefault(tmdb_id, []).append(
+                        (existing.service, existing.season_data)
+                    )
+                    unique_series[tmdb_id] = series
+                    continue
+            supplemental.setdefault(tmdb_id, []).append(
+                (series.service, series.season_data)
+            )
+
+    if skipped_count > 0:
+        LOG.warning(f"Skipped {skipped_count} series without TMDB IDs")
+
+    return unique_series, supplemental
+
+
 async def gather_series(
     service: MediaServerType | None = None,
 ) -> tuple[dict[int, AggregatedSeriesData], _SupplementalEpisodeData] | None:
@@ -1268,56 +1368,7 @@ async def gather_series(
                 aggregated_series.extend(get_series)
             LOG.debug(f"Fetched {len(get_series)} series from {server.service_type}")
 
-    # deduplicate series, keeping the one with most recent watch date.
-    # When a series appears in multiple services (e.g. Plex + Jellyfin), the losing
-    # service's season data is stored as supplemental so its episode IDs (plex_rating_key,
-    # jellyfin_episode_id, emby_episode_id) can still be written to the episodes table.
-    unique_series: dict[int, AggregatedSeriesData] = {}
-    supplemental: _SupplementalEpisodeData = {}
-    skipped_count = 0
-
-    for series in aggregated_series:
-        ext_ids = series.external_ids
-        if not ext_ids or not ext_ids.tmdb:
-            skipped_count += 1
-            continue
-
-        tmdb_id = ext_ids.tmdb
-        if tmdb_id not in unique_series:
-            unique_series[tmdb_id] = series
-        else:
-            existing = unique_series[tmdb_id]
-            # keep series with most recent watch date
-            if series.last_viewed_at and (
-                not existing.last_viewed_at
-                or series.last_viewed_at > existing.last_viewed_at
-            ):
-                # existing loses - stash its season data as supplemental
-                supplemental.setdefault(tmdb_id, []).append(
-                    (existing.service, existing.season_data)
-                )
-                unique_series[tmdb_id] = series
-            else:
-                # new series loses - stash its season data as supplemental
-                # (covers both the equal-date case and the "existing wins" case)
-                if series.last_viewed_at == existing.last_viewed_at:
-                    if series.added_at and (
-                        not existing.added_at or series.added_at > existing.added_at
-                    ):
-                        # new series wins on added_at - existing loses
-                        supplemental.setdefault(tmdb_id, []).append(
-                            (existing.service, existing.season_data)
-                        )
-                        unique_series[tmdb_id] = series
-                        continue
-                supplemental.setdefault(tmdb_id, []).append(
-                    (series.service, series.season_data)
-                )
-
-    if skipped_count > 0:
-        LOG.warning(f"Skipped {skipped_count} series without TMDB IDs")
-
-    return unique_series, supplemental
+    return _dedupe_aggregated_series(aggregated_series)
 
 
 async def sync_movies(

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -1375,6 +1375,10 @@ async def sync_movies(
             existing_by_imdb = {m.imdb_id: m for m in existing_movies_list if m.imdb_id}
 
             parsed_tmdb_ids: set[int] = set()
+            # row primary keys touched this run. parsed_tmdb_ids cannot serve
+            # this purpose: a row matched by the imdb fallback keeps its own
+            # tmdb_id, which is not the id that was just parsed.
+            matched_row_ids: set[int] = set()
 
             # iterate through aggregated movies
             batch_count = 0
@@ -1392,6 +1396,7 @@ async def sync_movies(
                 # if movie already exists, update it
                 if tmdb_id in existing_movies:
                     existing_movie = existing_movies[tmdb_id]
+                    matched_row_ids.add(existing_movie.id)
 
                     # update added_at if available
                     if earliest_added:
@@ -1431,6 +1436,7 @@ async def sync_movies(
                     imdb_id = movie.external_ids.imdb
                     if imdb_id and imdb_id in existing_by_imdb:
                         existing_movie = existing_by_imdb[imdb_id]
+                        matched_row_ids.add(existing_movie.id)
                         LOG.info(
                             f"Movie '{movie.name}' not found by tmdb_id ({tmdb_id}) but matched "
                             f"existing record by imdb_id ({imdb_id}) - updating instead of inserting"
@@ -1656,11 +1662,21 @@ async def sync_movies(
                 await session.commit()
 
             if allow_soft_delete:
-                movies_to_delete = [
-                    movie
-                    for movie in existing_movies.values()
-                    if movie.tmdb_id not in parsed_tmdb_ids and not movie.removed_at
-                ]
+                movies_to_delete = _select_rows_to_soft_delete(
+                    existing_movies_list, matched_row_ids
+                )
+                live_movie_count = sum(
+                    1 for movie in existing_movies_list if not movie.removed_at
+                )
+                if _soft_delete_guard_tripped(len(movies_to_delete), live_movie_count):
+                    LOG.warning(
+                        f"Skipping movie soft-delete: {len(movies_to_delete)} of "
+                        f"{live_movie_count} live movies would be removed, which "
+                        f"suggests a partial response from "
+                        f"{effective_service.value} rather than real deletions. "
+                        f"Deletions will run on the next healthy sync."
+                    )
+                    movies_to_delete = []
 
                 if movies_to_delete:
                     LOG.info(

--- a/tests/test_protected_removed_media.py
+++ b/tests/test_protected_removed_media.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from backend.api.routes.protected import get_protected_entries
+from backend.api.routes.v1.protections import list_protections
+from backend.database import Base
+from backend.database.models import Movie, ProtectedMedia, Series, User
+from backend.enums import MediaType, UserRole
+
+
+async def _seeded_session() -> tuple[
+    async_sessionmaker[AsyncSession], int, int, AsyncEngine
+]:
+    """A live and a tombstoned row for each media type, each manually protected.
+
+    Both movie and series are covered so a clause that only guards one media
+    type's null foreign key -- for example a broken
+    ``ProtectedMedia.series_id.is_(None)`` guard, under which a movie-keyed
+    row's NULL series_id would hit ``NULL.in_(subquery)`` and silently
+    evaluate to unknown -- gets exercised in both directions.
+
+    Returns the session maker, the live movie's id, the live series' id, and
+    the engine backing the session maker. The caller must dispose the engine
+    once done with it, otherwise the aiosqlite worker thread outlives the
+    event loop and pytest reports an unhandled thread exception in the
+    warnings summary.
+    """
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    async with session_maker() as db:
+        live_movie = Movie(title="Movie A", tmdb_id=2001, size=1)
+        tombstoned_movie = Movie(title="Movie B", tmdb_id=2002, size=1)
+        tombstoned_movie.removed_at = datetime.now(UTC)
+        live_series = Series(title="Series A", tmdb_id=1001, size=1)
+        tombstoned_series = Series(title="Series B", tmdb_id=1002, size=1)
+        tombstoned_series.removed_at = datetime.now(UTC)
+        db.add_all([live_movie, tombstoned_movie, live_series, tombstoned_series])
+        await db.flush()
+
+        live_movie_protection = ProtectedMedia(media_type=MediaType.MOVIE)
+        live_movie_protection.movie_id = live_movie.id
+        live_movie_protection.source = "manual"
+        tombstoned_movie_protection = ProtectedMedia(media_type=MediaType.MOVIE)
+        tombstoned_movie_protection.movie_id = tombstoned_movie.id
+        tombstoned_movie_protection.source = "manual"
+        live_series_protection = ProtectedMedia(media_type=MediaType.SERIES)
+        live_series_protection.series_id = live_series.id
+        live_series_protection.source = "manual"
+        tombstoned_series_protection = ProtectedMedia(media_type=MediaType.SERIES)
+        tombstoned_series_protection.series_id = tombstoned_series.id
+        tombstoned_series_protection.source = "manual"
+        db.add_all(
+            [
+                live_movie_protection,
+                tombstoned_movie_protection,
+                live_series_protection,
+                tombstoned_series_protection,
+            ]
+        )
+        await db.commit()
+        return session_maker, live_movie.id, live_series.id, engine
+
+
+@pytest.mark.anyio
+async def test_v1_list_excludes_protections_for_tombstoned_media() -> None:
+    """Manual protections now outlive their media, so the list must filter them.
+
+    Before the soft-delete fix these rows could not exist, so this filter is
+    additive: it only governs rows that fix started preserving. Both live
+    protections must still be present -- that's what would catch a clause
+    that wrongly hides the other media type instead of just the tombstoned
+    rows -- and both tombstoned protections must be absent.
+    """
+    session_maker, live_movie_id, live_series_id, engine = await _seeded_session()
+    async with session_maker() as db:
+        response = await list_protections(
+            _principal=None,  # type: ignore[arg-type]
+            db=db,
+            page=1,
+            per_page=50,
+            media_type=None,
+            media_id=None,
+            active_only=True,
+        )
+    await engine.dispose()
+
+    assert response.total == 2
+    seen = {(item.media_type, item.media_id) for item in response.items}
+    assert seen == {
+        (MediaType.MOVIE, live_movie_id),
+        (MediaType.SERIES, live_series_id),
+    }
+
+
+@pytest.mark.anyio
+async def test_ui_list_count_excludes_protections_for_tombstoned_media() -> None:
+    """The count query needs the same filter or it disagrees with the page."""
+    session_maker, _, _, engine = await _seeded_session()
+    async with session_maker() as db:
+        user = User(username="admin", password_hash="x", role=UserRole.ADMIN)
+        response = await get_protected_entries(
+            _user=user,
+            db=db,
+            page=1,
+            per_page=25,
+            search=None,
+            sort_by="created_at",
+            sort_order="desc",
+            media_type=None,
+        )
+    await engine.dispose()
+
+    assert response.total == 2

--- a/tests/test_requests_removed_media.py
+++ b/tests/test_requests_removed_media.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from backend.api.routes.requests import (
+    approve_request,
+    get_all_requests,
+    get_my_requests,
+)
+from backend.database import Base
+from backend.database.models import Movie, ProtectedMedia, ProtectionRequest, User
+from backend.enums import MediaType, ProtectionRequestStatus, UserRole
+from backend.models.requests import ReviewProtectionRequest
+
+
+async def _seeded_session() -> tuple[
+    async_sessionmaker[AsyncSession], User, int, int, AsyncEngine
+]:
+    """One pending request for live media and one for tombstoned media.
+
+    Both belong to the same user, so the "my requests" list and the admin list
+    see the same pair. Returns the session maker, the requesting user, the live
+    request's id, the tombstoned request's id, and the engine. The caller must
+    dispose the engine, otherwise the aiosqlite worker thread outlives the event
+    loop and pytest reports an unhandled thread exception.
+    """
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    async with session_maker() as db:
+        user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
+        live_movie = Movie(title="Movie A", tmdb_id=2001, size=1)
+        tombstoned_movie = Movie(title="Movie B", tmdb_id=2002, size=1)
+        tombstoned_movie.removed_at = datetime.now(UTC)
+        db.add_all([user, live_movie, tombstoned_movie])
+        await db.flush()
+
+        live_request = ProtectionRequest(
+            media_type=MediaType.MOVIE, requested_by_user_id=user.id
+        )
+        live_request.movie_id = live_movie.id
+        live_request.reason = "still here"
+        tombstoned_request = ProtectionRequest(
+            media_type=MediaType.MOVIE, requested_by_user_id=user.id
+        )
+        tombstoned_request.movie_id = tombstoned_movie.id
+        tombstoned_request.reason = "gone"
+        db.add_all([live_request, tombstoned_request])
+        await db.commit()
+        return session_maker, user, live_request.id, tombstoned_request.id, engine
+
+
+@pytest.mark.anyio
+async def test_my_requests_excludes_requests_for_tombstoned_media() -> None:
+    """A request outlives a soft-delete of its media, so the list must filter.
+
+    The `if not media: continue` bail does not cover this: the medium still
+    exists as a tombstone, so the relationship resolves and the request renders
+    for a title that appears nowhere else in the app.
+    """
+    session_maker, user, live_id, _, engine = await _seeded_session()
+    async with session_maker() as db:
+        responses = await get_my_requests(user=user, db=db, status_filter=None)
+    await engine.dispose()
+
+    assert [r.id for r in responses] == [live_id]
+
+
+@pytest.mark.anyio
+async def test_all_requests_excludes_requests_for_tombstoned_media() -> None:
+    """The admin queue would otherwise hold the request permanently."""
+    session_maker, user, live_id, _, engine = await _seeded_session()
+    async with session_maker() as db:
+        responses = await get_all_requests(
+            _manager=user, _page_user=user, db=db, status_filter=None
+        )
+    await engine.dispose()
+
+    assert [r.id for r in responses] == [live_id]
+
+
+@pytest.mark.anyio
+async def test_approving_a_request_for_tombstoned_media_is_refused() -> None:
+    """Approving would create a protection that the protected lists then hide.
+
+    The requester is told it worked, the admin sees the queue clear, and the
+    protection appears nowhere. Refuse instead, the same way creating a request
+    for removed media is refused.
+    """
+    session_maker, user, _, tombstoned_id, engine = await _seeded_session()
+    async with session_maker() as db:
+        with pytest.raises(HTTPException) as exc_info:
+            await approve_request(
+                request_id=tombstoned_id,
+                review_data=ReviewProtectionRequest(),
+                manager=user,
+                db=db,
+            )
+        await db.rollback()
+        protections = (await db.execute(select(ProtectedMedia))).scalars().all()
+        request = await db.get(ProtectionRequest, tombstoned_id)
+        assert request is not None
+        status_after = request.status
+    await engine.dispose()
+
+    assert exc_info.value.status_code == 404
+    assert protections == []
+    assert status_after is ProtectionRequestStatus.PENDING
+
+
+@pytest.mark.anyio
+async def test_approving_a_request_for_live_media_still_works() -> None:
+    """The refusal must not disable approval for media that is still present."""
+    session_maker, user, live_id, _, engine = await _seeded_session()
+    async with session_maker() as db:
+        response = await approve_request(
+            request_id=live_id,
+            review_data=ReviewProtectionRequest(),
+            manager=user,
+            db=db,
+        )
+        protections = (await db.execute(select(ProtectedMedia))).scalars().all()
+    await engine.dispose()
+
+    assert response.status is ProtectionRequestStatus.APPROVED
+    assert len(protections) == 1

--- a/tests/test_sync_series_scoping.py
+++ b/tests/test_sync_series_scoping.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from backend.database import Base
 from backend.enums import Service
@@ -37,11 +42,22 @@ def _async_db_override(session_maker: async_sessionmaker[AsyncSession]):
     return _override
 
 
-async def _in_memory_session_maker() -> async_sessionmaker[AsyncSession]:
+async def _in_memory_session_maker() -> tuple[
+    async_sessionmaker[AsyncSession], AsyncEngine
+]:
+    """Returns the session maker and the engine backing it.
+
+    The caller must dispose the engine, otherwise the aiosqlite worker thread
+    outlives the event loop and pytest reports an unhandled thread exception in
+    the warnings summary.
+    """
     engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    session_maker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    return session_maker, engine
 
 
 @pytest.mark.anyio
@@ -52,7 +68,7 @@ async def test_linked_server_does_not_sync_series(monkeypatch) -> None:
     so a resync gathered series from every configured server and the table
     became the union of all of them.
     """
-    session_maker = await _in_memory_session_maker()
+    session_maker, engine = await _in_memory_session_maker()
     monkeypatch.setattr(
         "backend.tasks.sync.async_db", _async_db_override(session_maker)
     )
@@ -66,6 +82,7 @@ async def test_linked_server_does_not_sync_series(monkeypatch) -> None:
     monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
 
     result = await sync_module.sync_series(Service.PLEX)
+    await engine.dispose()
 
     assert result == set()
     assert gather.called_with == []
@@ -79,7 +96,7 @@ async def test_the_main_server_passed_explicitly_syncs_normally(monkeypatch) -> 
     `if service is not None: return set()` would satisfy while disabling series
     syncing across the whole application. This is the test that catches it.
     """
-    session_maker = await _in_memory_session_maker()
+    session_maker, engine = await _in_memory_session_maker()
     monkeypatch.setattr(
         "backend.tasks.sync.async_db", _async_db_override(session_maker)
     )
@@ -93,6 +110,7 @@ async def test_the_main_server_passed_explicitly_syncs_normally(monkeypatch) -> 
     monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
 
     await sync_module.sync_series(Service.JELLYFIN)
+    await engine.dispose()
 
     assert gather.called_with == [Service.JELLYFIN]
 
@@ -103,7 +121,7 @@ async def test_no_service_resolves_to_the_main_server(monkeypatch) -> None:
 
     That must mean the main server, matching sync_movies, not every server.
     """
-    session_maker = await _in_memory_session_maker()
+    session_maker, engine = await _in_memory_session_maker()
     monkeypatch.setattr(
         "backend.tasks.sync.async_db", _async_db_override(session_maker)
     )
@@ -117,13 +135,14 @@ async def test_no_service_resolves_to_the_main_server(monkeypatch) -> None:
     monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
 
     await sync_module.sync_series()
+    await engine.dispose()
 
     assert gather.called_with == [Service.JELLYFIN]
 
 
 @pytest.mark.anyio
 async def test_no_main_server_configured_returns_empty(monkeypatch) -> None:
-    session_maker = await _in_memory_session_maker()
+    session_maker, engine = await _in_memory_session_maker()
     monkeypatch.setattr(
         "backend.tasks.sync.async_db", _async_db_override(session_maker)
     )
@@ -137,6 +156,7 @@ async def test_no_main_server_configured_returns_empty(monkeypatch) -> None:
     monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
 
     result = await sync_module.sync_series()
+    await engine.dispose()
 
     assert result == set()
     assert gather.called_with == []

--- a/tests/test_sync_series_scoping.py
+++ b/tests/test_sync_series_scoping.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.database import Base
+from backend.enums import Service
+from backend.tasks import sync as sync_module
+
+
+@dataclass
+class _FakeServerConfig:
+    service_type: Service
+
+
+class _RecordingGather:
+    """Captures the service gather_series was asked for."""
+
+    def __init__(self) -> None:
+        self.called_with: list[Any] = []
+
+    async def __call__(self, service: Any = None) -> None:
+        self.called_with.append(service)
+        return None
+
+
+def _async_db_override(session_maker: async_sessionmaker[AsyncSession]):
+    @asynccontextmanager
+    async def _override():
+        async with session_maker() as session:
+            yield session
+
+    return _override
+
+
+async def _in_memory_session_maker() -> async_sessionmaker[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest.mark.anyio
+async def test_linked_server_does_not_sync_series(monkeypatch) -> None:
+    """A non-main server must not contribute series rows.
+
+    sync_movies already returns early for a linked server. sync_series did not,
+    so a resync gathered series from every configured server and the table
+    became the union of all of them.
+    """
+    session_maker = await _in_memory_session_maker()
+    monkeypatch.setattr(
+        "backend.tasks.sync.async_db", _async_db_override(session_maker)
+    )
+
+    gather = _RecordingGather()
+    monkeypatch.setattr(sync_module, "gather_series", gather)
+
+    async def _fake_main(_session: Any) -> _FakeServerConfig:
+        return _FakeServerConfig(service_type=Service.JELLYFIN)
+
+    monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
+
+    result = await sync_module.sync_series(Service.PLEX)
+
+    assert result == set()
+    assert gather.called_with == []
+
+
+@pytest.mark.anyio
+async def test_no_service_resolves_to_the_main_server(monkeypatch) -> None:
+    """resync_media calls sync_series() with no argument.
+
+    That must mean the main server, matching sync_movies, not every server.
+    """
+    session_maker = await _in_memory_session_maker()
+    monkeypatch.setattr(
+        "backend.tasks.sync.async_db", _async_db_override(session_maker)
+    )
+
+    gather = _RecordingGather()
+    monkeypatch.setattr(sync_module, "gather_series", gather)
+
+    async def _fake_main(_session: Any) -> _FakeServerConfig:
+        return _FakeServerConfig(service_type=Service.JELLYFIN)
+
+    monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
+
+    await sync_module.sync_series()
+
+    assert gather.called_with == [Service.JELLYFIN]
+
+
+@pytest.mark.anyio
+async def test_no_main_server_configured_returns_empty(monkeypatch) -> None:
+    session_maker = await _in_memory_session_maker()
+    monkeypatch.setattr(
+        "backend.tasks.sync.async_db", _async_db_override(session_maker)
+    )
+
+    gather = _RecordingGather()
+    monkeypatch.setattr(sync_module, "gather_series", gather)
+
+    async def _fake_main(_session: Any) -> None:
+        return None
+
+    monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
+
+    result = await sync_module.sync_series()
+
+    assert result == set()
+    assert gather.called_with == []

--- a/tests/test_sync_series_scoping.py
+++ b/tests/test_sync_series_scoping.py
@@ -72,6 +72,32 @@ async def test_linked_server_does_not_sync_series(monkeypatch) -> None:
 
 
 @pytest.mark.anyio
+async def test_the_main_server_passed_explicitly_syncs_normally(monkeypatch) -> None:
+    """sync_media passes the main server by name, so this is the normal path.
+
+    Every other test here asserts that gather is not reached, which a guard of
+    `if service is not None: return set()` would satisfy while disabling series
+    syncing across the whole application. This is the test that catches it.
+    """
+    session_maker = await _in_memory_session_maker()
+    monkeypatch.setattr(
+        "backend.tasks.sync.async_db", _async_db_override(session_maker)
+    )
+
+    gather = _RecordingGather()
+    monkeypatch.setattr(sync_module, "gather_series", gather)
+
+    async def _fake_main(_session: Any) -> _FakeServerConfig:
+        return _FakeServerConfig(service_type=Service.JELLYFIN)
+
+    monkeypatch.setattr(sync_module, "_get_main_media_server", _fake_main)
+
+    await sync_module.sync_series(Service.JELLYFIN)
+
+    assert gather.called_with == [Service.JELLYFIN]
+
+
+@pytest.mark.anyio
 async def test_no_service_resolves_to_the_main_server(monkeypatch) -> None:
     """resync_media calls sync_series() with no argument.
 

--- a/tests/test_sync_soft_delete.py
+++ b/tests/test_sync_soft_delete.py
@@ -197,10 +197,10 @@ async def test_apply_soft_deletes_targets_movies_by_movie_id() -> None:
 
 @pytest.mark.anyio
 async def test_apply_soft_deletes_removes_protected_media_rows() -> None:
-    """Today both manual and rule-sourced protection go with the row.
+    """Only rule-sourced protection is removed; it regenerates from the rule task.
 
-    Task 5 changes this policy; this test is the before-picture it changes
-    against.
+    Manual protection is a person's decision and nothing can rebuild it, so it
+    must survive.
     """
     session_maker = await _memory_session_maker()
     async with session_maker() as db:
@@ -220,11 +220,13 @@ async def test_apply_soft_deletes_removes_protected_media_rows() -> None:
         await _apply_soft_deletes(db, [series], MediaType.SERIES)
         await db.commit()
 
-        assert (await db.execute(select(ProtectedMedia))).scalars().all() == []
+        remaining = (await db.execute(select(ProtectedMedia))).scalars().all()
+        assert [p.source for p in remaining] == ["manual"]
 
 
 @pytest.mark.anyio
-async def test_apply_soft_deletes_removes_protection_request_rows() -> None:
+async def test_apply_soft_deletes_leaves_protection_request_rows_alone() -> None:
+    """A protection request is a human decision that nothing can rebuild."""
     session_maker = await _memory_session_maker()
     async with session_maker() as db:
         user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
@@ -242,7 +244,7 @@ async def test_apply_soft_deletes_removes_protection_request_rows() -> None:
         await _apply_soft_deletes(db, [series], MediaType.SERIES)
         await db.commit()
 
-        assert (await db.execute(select(ProtectionRequest))).scalars().all() == []
+        assert len((await db.execute(select(ProtectionRequest))).scalars().all()) == 1
 
 
 @pytest.mark.anyio
@@ -280,3 +282,78 @@ async def test_apply_soft_deletes_leaves_other_medium_protection_alone() -> None
         assert [p.series_id for p in remaining_protection] == [unrelated.id]
         assert [r.series_id for r in remaining_requests] == [unrelated.id]
         assert unrelated.removed_at is None
+
+
+def _protection(series_id: int, source: str) -> ProtectedMedia:
+    protection = ProtectedMedia(media_type=MediaType.SERIES)
+    protection.series_id = series_id
+    protection.source = source
+    return protection
+
+
+@pytest.mark.anyio
+async def test_manual_protection_survives_a_tombstone() -> None:
+    """A person's decision cannot be reconstructed, so it must not be deleted.
+
+    The medium is only soft-deleted and is restored if it reappears. Hard-deleting
+    the protection meant that restore came back silently unprotected.
+    """
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        series = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add(series)
+        await db.flush()
+        db.add_all([_protection(series.id, "manual"), _protection(series.id, "rule")])
+        await db.commit()
+
+        await _apply_soft_deletes(db, [series], MediaType.SERIES)
+        await db.commit()
+
+        remaining = (await db.execute(select(ProtectedMedia))).scalars().all()
+        assert [p.source for p in remaining] == ["manual"]
+
+
+@pytest.mark.anyio
+async def test_protection_request_survives_a_tombstone() -> None:
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
+        series = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add_all([user, series])
+        await db.flush()
+
+        request = ProtectionRequest(
+            media_type=MediaType.SERIES, requested_by_user_id=user.id
+        )
+        request.series_id = series.id
+        db.add(request)
+        await db.commit()
+
+        await _apply_soft_deletes(db, [series], MediaType.SERIES)
+        await db.commit()
+
+        assert len((await db.execute(select(ProtectionRequest))).scalars().all()) == 1
+
+
+@pytest.mark.anyio
+async def test_manual_protection_is_still_attached_after_a_restore() -> None:
+    """The point of preserving it: the protection must mean something again.
+
+    A restore is just clearing removed_at, which is what sync_series does when
+    the media reappears.
+    """
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        series = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add(series)
+        await db.flush()
+        db.add(_protection(series.id, "manual"))
+        await db.commit()
+
+        await _apply_soft_deletes(db, [series], MediaType.SERIES)
+        await db.commit()
+        series.removed_at = None
+        await db.commit()
+
+        protections = (await db.execute(select(ProtectedMedia))).scalars().all()
+        assert [p.series_id for p in protections] == [series.id]

--- a/tests/test_sync_soft_delete.py
+++ b/tests/test_sync_soft_delete.py
@@ -4,7 +4,12 @@ from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from backend.database import Base
 from backend.database.models import (
@@ -183,17 +188,28 @@ def test_set_membership_not_ordering_decides_the_repeat() -> None:
     )
 
 
-async def _memory_session_maker() -> async_sessionmaker[AsyncSession]:
+async def _memory_session_maker() -> tuple[
+    async_sessionmaker[AsyncSession], AsyncEngine
+]:
+    """Returns the session maker and the engine backing it.
+
+    The caller must dispose the engine, otherwise the aiosqlite worker thread
+    outlives the event loop and pytest reports an unhandled thread exception in
+    the warnings summary.
+    """
     engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    session_maker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    return session_maker, engine
 
 
 @pytest.mark.anyio
 async def test_apply_soft_deletes_tombstones_without_hard_deleting_the_row() -> None:
     """The row survives so its metadata is reusable if the media comes back."""
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         series = Series(title="Series A", tmdb_id=1001, size=1)
         series.arr_added_at = datetime.now(UTC)
@@ -210,11 +226,12 @@ async def test_apply_soft_deletes_tombstones_without_hard_deleting_the_row() -> 
         assert stored[0].removed_at is not None
         assert stored[0].added_at is None
         assert stored[0].arr_added_at is None
+    await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_apply_soft_deletes_removes_derived_candidate_rows() -> None:
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         series = Series(title="Series A", tmdb_id=1001, size=1)
         db.add(series)
@@ -234,19 +251,21 @@ async def test_apply_soft_deletes_removes_derived_candidate_rows() -> None:
         await db.commit()
 
         assert (await db.execute(select(ReclaimCandidate))).scalars().all() == []
+    await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_apply_soft_deletes_on_an_empty_set_is_a_no_op() -> None:
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         assert await _apply_soft_deletes(db, [], MediaType.SERIES) == []
+    await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_apply_soft_deletes_targets_movies_by_movie_id() -> None:
     """The wrong foreign key would delete another medium's derived rows."""
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         movie = Movie(title="Movie A", tmdb_id=2001, size=1)
         unrelated = Series(title="Series A", tmdb_id=1001, size=1)
@@ -269,6 +288,7 @@ async def test_apply_soft_deletes_targets_movies_by_movie_id() -> None:
         remaining = (await db.execute(select(ReclaimCandidate))).scalars().all()
         assert [c.series_id for c in remaining] == [unrelated.id]
         assert unrelated.removed_at is None
+    await engine.dispose()
 
 
 @pytest.mark.anyio
@@ -278,7 +298,7 @@ async def test_apply_soft_deletes_removes_protected_media_rows() -> None:
     Manual protection is a person's decision and nothing can rebuild it, so it
     must survive.
     """
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         series = Series(title="Series A", tmdb_id=1001, size=1)
         db.add(series)
@@ -298,12 +318,13 @@ async def test_apply_soft_deletes_removes_protected_media_rows() -> None:
 
         remaining = (await db.execute(select(ProtectedMedia))).scalars().all()
         assert [p.source for p in remaining] == ["manual"]
+    await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_apply_soft_deletes_leaves_protection_request_rows_alone() -> None:
     """A protection request is a human decision that nothing can rebuild."""
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
         series = Series(title="Series A", tmdb_id=1001, size=1)
@@ -321,6 +342,7 @@ async def test_apply_soft_deletes_leaves_protection_request_rows_alone() -> None
         await db.commit()
 
         assert len((await db.execute(select(ProtectionRequest))).scalars().all()) == 1
+    await engine.dispose()
 
 
 @pytest.mark.anyio
@@ -328,7 +350,7 @@ async def test_apply_soft_deletes_leaves_other_medium_protection_alone() -> None
     """The same shape as targeting by foreign key: an unrelated medium's
     protection rows must survive a soft-delete of a different medium.
     """
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
         movie = Movie(title="Movie A", tmdb_id=2001, size=1)
@@ -358,6 +380,7 @@ async def test_apply_soft_deletes_leaves_other_medium_protection_alone() -> None
         assert [p.series_id for p in remaining_protection] == [unrelated.id]
         assert [r.series_id for r in remaining_requests] == [unrelated.id]
         assert unrelated.removed_at is None
+    await engine.dispose()
 
 
 def _protection(series_id: int, source: str) -> ProtectedMedia:
@@ -374,7 +397,7 @@ async def test_manual_protection_survives_a_tombstone() -> None:
     The medium is only soft-deleted and is restored if it reappears. Hard-deleting
     the protection meant that restore came back silently unprotected.
     """
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         series = Series(title="Series A", tmdb_id=1001, size=1)
         db.add(series)
@@ -387,11 +410,12 @@ async def test_manual_protection_survives_a_tombstone() -> None:
 
         remaining = (await db.execute(select(ProtectedMedia))).scalars().all()
         assert [p.source for p in remaining] == ["manual"]
+    await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_protection_request_survives_a_tombstone() -> None:
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
         series = Series(title="Series A", tmdb_id=1001, size=1)
@@ -409,6 +433,7 @@ async def test_protection_request_survives_a_tombstone() -> None:
         await db.commit()
 
         assert len((await db.execute(select(ProtectionRequest))).scalars().all()) == 1
+    await engine.dispose()
 
 
 @pytest.mark.anyio
@@ -418,7 +443,7 @@ async def test_manual_protection_is_still_attached_after_a_restore() -> None:
     A restore is just clearing removed_at, which is what sync_series does when
     the media reappears.
     """
-    session_maker = await _memory_session_maker()
+    session_maker, engine = await _memory_session_maker()
     async with session_maker() as db:
         series = Series(title="Series A", tmdb_id=1001, size=1)
         db.add(series)
@@ -433,3 +458,4 @@ async def test_manual_protection_is_still_attached_after_a_restore() -> None:
 
         protections = (await db.execute(select(ProtectedMedia))).scalars().all()
         assert [p.series_id for p in protections] == [series.id]
+    await engine.dispose()

--- a/tests/test_sync_soft_delete.py
+++ b/tests/test_sync_soft_delete.py
@@ -20,9 +20,19 @@ from backend.tasks.sync import (
     MAX_SOFT_DELETE_RATIO,
     MIN_LIBRARY_FOR_RATIO_CHECK,
     _apply_soft_deletes,
+    _previous_large_delete_sets,
     _select_rows_to_soft_delete,
+    _soft_delete_blocked,
     _soft_delete_guard_tripped,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_remembered_delete_sets():
+    """The two-strikes memory is module state; do not leak it between tests."""
+    _previous_large_delete_sets.clear()
+    yield
+    _previous_large_delete_sets.clear()
 
 
 def _series(row_id: int, tmdb_id: int, removed: bool = False) -> Series:
@@ -105,6 +115,72 @@ def test_guard_floor_is_the_documented_constant() -> None:
 def test_ratio_constant_is_the_documented_value() -> None:
     assert MAX_SOFT_DELETE_RATIO == 0.5
     assert MIN_LIBRARY_FOR_RATIO_CHECK == 20
+
+
+def _large_delete_set(first_id: int = 1) -> list[Series]:
+    """Over-ratio against a live count of 100, and past the small-library floor."""
+    return [_series(row_id, 1000 + row_id) for row_id in range(first_id, first_id + 60)]
+
+
+def test_the_same_large_delete_set_is_allowed_on_the_second_run() -> None:
+    """Blocking on the ratio alone never relents after a main-server switch.
+
+    The phantom rows the pass wants gone are themselves counted as live, so the
+    delete set stays over the ratio every run and the pass is skipped forever.
+    A set proposed twice is a real reduction, not a flapping server.
+    """
+    rows = _large_delete_set()
+
+    assert _soft_delete_blocked(MediaType.SERIES, rows, live_count=100) is True
+    assert _soft_delete_blocked(MediaType.SERIES, rows, live_count=100) is False
+
+
+def test_a_different_large_delete_set_each_run_stays_blocked() -> None:
+    """The case the guard is actually for: a server answering inconsistently."""
+    assert (
+        _soft_delete_blocked(MediaType.SERIES, _large_delete_set(1), live_count=100)
+        is True
+    )
+    assert (
+        _soft_delete_blocked(MediaType.SERIES, _large_delete_set(500), live_count=100)
+        is True
+    )
+    assert (
+        _soft_delete_blocked(MediaType.SERIES, _large_delete_set(900), live_count=100)
+        is True
+    )
+
+
+def test_a_healthy_run_clears_the_remembered_set() -> None:
+    """A sub-threshold run means the earlier set was never confirmed."""
+    rows = _large_delete_set()
+
+    assert _soft_delete_blocked(MediaType.SERIES, rows, live_count=100) is True
+    assert _soft_delete_blocked(MediaType.SERIES, rows[:1], live_count=100) is False
+    assert _previous_large_delete_sets == {}
+    assert _soft_delete_blocked(MediaType.SERIES, rows, live_count=100) is True
+
+
+def test_the_two_media_types_are_remembered_separately() -> None:
+    """A movie pass must not confirm a series pass, or vice versa."""
+    series_rows = _large_delete_set()
+    movie_rows = [_movie(row_id, 2000 + row_id) for row_id in range(1, 61)]
+
+    assert _soft_delete_blocked(MediaType.SERIES, series_rows, live_count=100) is True
+    assert _soft_delete_blocked(MediaType.MOVIE, movie_rows, live_count=100) is True
+    assert _soft_delete_blocked(MediaType.SERIES, series_rows, live_count=100) is False
+    assert _soft_delete_blocked(MediaType.MOVIE, movie_rows, live_count=100) is False
+
+
+def test_set_membership_not_ordering_decides_the_repeat() -> None:
+    """Row order comes from the media server and carries no meaning."""
+    rows = _large_delete_set()
+
+    assert _soft_delete_blocked(MediaType.SERIES, rows, live_count=100) is True
+    assert (
+        _soft_delete_blocked(MediaType.SERIES, list(reversed(rows)), live_count=100)
+        is False
+    )
 
 
 async def _memory_session_maker() -> async_sessionmaker[AsyncSession]:

--- a/tests/test_sync_soft_delete.py
+++ b/tests/test_sync_soft_delete.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.database import Base
+from backend.database.models import (
+    Movie,
+    ProtectedMedia,
+    ProtectionRequest,
+    ReclaimCandidate,
+    Series,
+    User,
+)
+from backend.enums import MediaType, UserRole
+from backend.tasks.sync import (
+    MAX_SOFT_DELETE_RATIO,
+    MIN_LIBRARY_FOR_RATIO_CHECK,
+    _apply_soft_deletes,
+    _select_rows_to_soft_delete,
+    _soft_delete_guard_tripped,
+)
+
+
+def _series(row_id: int, tmdb_id: int, removed: bool = False) -> Series:
+    series = Series(title=f"Series {row_id}", tmdb_id=tmdb_id, size=1)
+    series.id = row_id
+    series.removed_at = datetime.now(UTC) if removed else None
+    return series
+
+
+def _movie(row_id: int, tmdb_id: int, removed: bool = False) -> Movie:
+    movie = Movie(title=f"Movie {row_id}", tmdb_id=tmdb_id, size=1)
+    movie.id = row_id
+    movie.removed_at = datetime.now(UTC) if removed else None
+    return movie
+
+
+def test_untouched_row_is_selected() -> None:
+    rows = [_series(1, 1001), _series(2, 1002)]
+
+    result = _select_rows_to_soft_delete(rows, {1})
+
+    assert [r.id for r in result] == [2]
+
+
+def test_row_matched_under_a_different_tmdb_id_is_not_selected() -> None:
+    """The regression this whole change exists for.
+
+    The row holds tmdb 1001. The main server reported the same show under
+    tmdb 1002 and the tvdb fallback matched it, so the row was updated. Keying
+    the delete pass on tmdb ids would tombstone a row that is still live.
+    """
+    row = _series(1, 1001)
+
+    result = _select_rows_to_soft_delete([row], matched_row_ids={1})
+
+    assert result == []
+
+
+def test_already_tombstoned_row_is_not_selected_again() -> None:
+    rows = [_series(1, 1001, removed=True)]
+
+    result = _select_rows_to_soft_delete(rows, set())
+
+    assert result == []
+
+
+def test_movies_use_the_same_selection() -> None:
+    rows = [_movie(1, 2001), _movie(2, 2002)]
+
+    result = _select_rows_to_soft_delete(rows, {2})
+
+    assert [r.id for r in result] == [1]
+
+
+def test_guard_trips_when_delete_set_exceeds_the_ratio() -> None:
+    assert _soft_delete_guard_tripped(delete_count=60, live_count=100) is True
+
+
+def test_guard_allows_a_delete_set_at_the_ratio() -> None:
+    assert _soft_delete_guard_tripped(delete_count=50, live_count=100) is False
+
+
+def test_guard_is_disabled_for_small_libraries() -> None:
+    """Removing three of four items is legitimate; do not block it."""
+    assert _soft_delete_guard_tripped(delete_count=3, live_count=4) is False
+
+
+def test_guard_floor_is_the_documented_constant() -> None:
+    below = MIN_LIBRARY_FOR_RATIO_CHECK - 1
+    assert _soft_delete_guard_tripped(delete_count=below, live_count=below) is False
+    assert (
+        _soft_delete_guard_tripped(
+            delete_count=MIN_LIBRARY_FOR_RATIO_CHECK,
+            live_count=MIN_LIBRARY_FOR_RATIO_CHECK,
+        )
+        is True
+    )
+
+
+def test_ratio_constant_is_the_documented_value() -> None:
+    assert MAX_SOFT_DELETE_RATIO == 0.5
+    assert MIN_LIBRARY_FOR_RATIO_CHECK == 20
+
+
+async def _memory_session_maker() -> async_sessionmaker[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest.mark.anyio
+async def test_apply_soft_deletes_tombstones_without_hard_deleting_the_row() -> None:
+    """The row survives so its metadata is reusable if the media comes back."""
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        series = Series(title="Series A", tmdb_id=1001, size=1)
+        series.arr_added_at = datetime.now(UTC)
+        db.add(series)
+        await db.flush()
+        row_id = series.id
+
+        deleted_ids = await _apply_soft_deletes(db, [series], MediaType.SERIES)
+        await db.commit()
+
+        assert deleted_ids == [row_id]
+        stored = (await db.execute(select(Series))).scalars().all()
+        assert len(stored) == 1
+        assert stored[0].removed_at is not None
+        assert stored[0].added_at is None
+        assert stored[0].arr_added_at is None
+
+
+@pytest.mark.anyio
+async def test_apply_soft_deletes_removes_derived_candidate_rows() -> None:
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        series = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add(series)
+        await db.flush()
+
+        candidate = ReclaimCandidate(
+            media_type=MediaType.SERIES,
+            matched_rule_ids=[1],
+            matched_criteria={},
+            reason="test",
+        )
+        candidate.series_id = series.id
+        db.add(candidate)
+        await db.commit()
+
+        await _apply_soft_deletes(db, [series], MediaType.SERIES)
+        await db.commit()
+
+        assert (await db.execute(select(ReclaimCandidate))).scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_apply_soft_deletes_on_an_empty_set_is_a_no_op() -> None:
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        assert await _apply_soft_deletes(db, [], MediaType.SERIES) == []
+
+
+@pytest.mark.anyio
+async def test_apply_soft_deletes_targets_movies_by_movie_id() -> None:
+    """The wrong foreign key would delete another medium's derived rows."""
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        movie = Movie(title="Movie A", tmdb_id=2001, size=1)
+        unrelated = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add_all([movie, unrelated])
+        await db.flush()
+
+        series_candidate = ReclaimCandidate(
+            media_type=MediaType.SERIES,
+            matched_rule_ids=[1],
+            matched_criteria={},
+            reason="test",
+        )
+        series_candidate.series_id = unrelated.id
+        db.add(series_candidate)
+        await db.commit()
+
+        await _apply_soft_deletes(db, [movie], MediaType.MOVIE)
+        await db.commit()
+
+        remaining = (await db.execute(select(ReclaimCandidate))).scalars().all()
+        assert [c.series_id for c in remaining] == [unrelated.id]
+        assert unrelated.removed_at is None
+
+
+@pytest.mark.anyio
+async def test_apply_soft_deletes_removes_protected_media_rows() -> None:
+    """Today both manual and rule-sourced protection go with the row.
+
+    Task 5 changes this policy; this test is the before-picture it changes
+    against.
+    """
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        series = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add(series)
+        await db.flush()
+
+        manual = ProtectedMedia(media_type=MediaType.SERIES)
+        manual.series_id = series.id
+        manual.source = "manual"
+        rule = ProtectedMedia(media_type=MediaType.SERIES)
+        rule.series_id = series.id
+        rule.source = "rule"
+        db.add_all([manual, rule])
+        await db.commit()
+
+        await _apply_soft_deletes(db, [series], MediaType.SERIES)
+        await db.commit()
+
+        assert (await db.execute(select(ProtectedMedia))).scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_apply_soft_deletes_removes_protection_request_rows() -> None:
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
+        series = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add_all([user, series])
+        await db.flush()
+
+        request = ProtectionRequest(
+            media_type=MediaType.SERIES, requested_by_user_id=user.id
+        )
+        request.series_id = series.id
+        db.add(request)
+        await db.commit()
+
+        await _apply_soft_deletes(db, [series], MediaType.SERIES)
+        await db.commit()
+
+        assert (await db.execute(select(ProtectionRequest))).scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_apply_soft_deletes_leaves_other_medium_protection_alone() -> None:
+    """The same shape as targeting by foreign key: an unrelated medium's
+    protection rows must survive a soft-delete of a different medium.
+    """
+    session_maker = await _memory_session_maker()
+    async with session_maker() as db:
+        user = User(username="someone", password_hash="x", role=UserRole.ADMIN)
+        movie = Movie(title="Movie A", tmdb_id=2001, size=1)
+        unrelated = Series(title="Series A", tmdb_id=1001, size=1)
+        db.add_all([user, movie, unrelated])
+        await db.flush()
+
+        protection = ProtectedMedia(media_type=MediaType.SERIES)
+        protection.series_id = unrelated.id
+        protection.source = "manual"
+        request = ProtectionRequest(
+            media_type=MediaType.SERIES, requested_by_user_id=user.id
+        )
+        request.series_id = unrelated.id
+        db.add_all([protection, request])
+        await db.commit()
+
+        await _apply_soft_deletes(db, [movie], MediaType.MOVIE)
+        await db.commit()
+
+        remaining_protection = (
+            (await db.execute(select(ProtectedMedia))).scalars().all()
+        )
+        remaining_requests = (
+            (await db.execute(select(ProtectionRequest))).scalars().all()
+        )
+        assert [p.series_id for p in remaining_protection] == [unrelated.id]
+        assert [r.series_id for r in remaining_requests] == [unrelated.id]
+        assert unrelated.removed_at is None

--- a/tests/test_sync_tmdb_collision.py
+++ b/tests/test_sync_tmdb_collision.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from backend.enums import Service
+from backend.models.media import AggregatedSeasonData, AggregatedSeriesData, ExternalIDs
+from backend.tasks.sync import _dedupe_aggregated_series, _tvdb_sorts_first
+
+
+def _season_data(service_series_id: str) -> list[AggregatedSeasonData]:
+    """A minimal, distinguishable season payload for stash-identity assertions."""
+    return [
+        AggregatedSeasonData(
+            service_series_id=service_series_id,
+            season_number=1,
+            size=1,
+            episode_count=1,
+            view_count=0,
+            last_viewed_at=None,
+        )
+    ]
+
+
+def _series_data(
+    name: str,
+    tmdb: int,
+    tvdb: str | None,
+    service: Service = Service.JELLYFIN,
+    last_viewed_at: datetime | None = None,
+    season_data: list[AggregatedSeasonData] | None = None,
+) -> AggregatedSeriesData:
+    return AggregatedSeriesData(
+        id=f"item-{name}",
+        name=name,
+        year=2020,
+        service=service,
+        library_name="Shows",
+        library_id="1",
+        path=None,
+        added_at=None,
+        external_ids=ExternalIDs(tmdb=tmdb, imdb=None, tmdb_collection=None, tvdb=tvdb),
+        size=1,
+        view_count=0,
+        last_viewed_at=last_viewed_at,
+        season_data=season_data if season_data is not None else [],
+    )
+
+
+def test_numeric_tvdb_ids_sort_numerically_not_lexicographically() -> None:
+    assert _tvdb_sorts_first("9001", "10001") is True
+    assert _tvdb_sorts_first("10001", "9001") is False
+
+
+def test_non_numeric_tvdb_ids_fall_back_to_string_order() -> None:
+    assert _tvdb_sorts_first("abc", "abd") is True
+
+
+def test_identical_tvdb_ids_do_not_sort_first_either_way() -> None:
+    assert _tvdb_sorts_first("9001", "9001") is False
+
+
+def test_two_series_sharing_a_tmdb_id_are_not_merged() -> None:
+    """Distinct tvdb ids prove these are different series, not one seen twice.
+
+    Merging them stashes the loser's season data as supplemental, which then
+    writes the loser's episode ids onto the winner's episode rows.
+    """
+    a = _series_data("Series A", tmdb=1001, tvdb="9001")
+    b = _series_data("Series B", tmdb=1001, tvdb="9002")
+
+    unique, supplemental = _dedupe_aggregated_series([a, b])
+
+    assert list(unique) == [1001]
+    assert supplemental == {}
+
+
+def test_collision_winner_is_the_lower_tvdb_id() -> None:
+    a = _series_data("Series A", tmdb=1001, tvdb="9002")
+    b = _series_data("Series B", tmdb=1001, tvdb="9001")
+
+    unique, _ = _dedupe_aggregated_series([a, b])
+
+    assert unique[1001].name == "Series B"
+
+
+def test_collision_winner_ignores_watch_dates() -> None:
+    """Ownership must not flip when someone watches the other series."""
+    recent = datetime.now(UTC)
+    a = _series_data("Series A", tmdb=1001, tvdb="9001", last_viewed_at=recent)
+    b = _series_data(
+        "Series B",
+        tmdb=1001,
+        tvdb="9002",
+        last_viewed_at=recent + timedelta(days=1),
+    )
+
+    unique, _ = _dedupe_aggregated_series([a, b])
+
+    assert unique[1001].name == "Series A"
+
+
+def test_collision_winner_is_order_independent() -> None:
+    a = _series_data("Series A", tmdb=1001, tvdb="9001")
+    b = _series_data("Series B", tmdb=1001, tvdb="9002")
+
+    forward, _ = _dedupe_aggregated_series([a, b])
+    reverse, _ = _dedupe_aggregated_series([b, a])
+
+    assert forward[1001].name == reverse[1001].name == "Series A"
+
+
+def test_same_series_on_two_services_still_merges() -> None:
+    """The cross-service merge this dedup was written for must be preserved."""
+    older = datetime.now(UTC)
+    jellyfin = _series_data(
+        "Series A",
+        tmdb=1001,
+        tvdb="9001",
+        service=Service.JELLYFIN,
+        last_viewed_at=older,
+        season_data=_season_data("jellyfin-series"),
+    )
+    plex = _series_data(
+        "Series A",
+        tmdb=1001,
+        tvdb="9001",
+        service=Service.PLEX,
+        last_viewed_at=older + timedelta(days=1),
+        season_data=_season_data("plex-series"),
+    )
+
+    unique, supplemental = _dedupe_aggregated_series([jellyfin, plex])
+
+    assert unique[1001].service is Service.PLEX
+    # exact contents, not just presence - a transposed stash (winner's data
+    # instead of the loser's) must fail this, not slip through as "some entry"
+    assert supplemental[1001] == [(Service.JELLYFIN, jellyfin.season_data)]
+
+
+def test_collision_drops_stale_supplemental_from_the_incumbent_it_displaces() -> None:
+    """A collision winner must not inherit supplemental stashed under the loser.
+
+    Two servers report the same Series A, which merges normally first and
+    stashes the losing server's season data under tmdb 1001. Series B then
+    collides on that same tmdb id and wins. The Series A stash from that
+    unrelated merge must not survive, or Series A's episode ids graft onto
+    Series B's episode rows.
+    """
+    a_server1 = _series_data(
+        "Series A",
+        tmdb=1001,
+        tvdb="9002",
+        service=Service.JELLYFIN,
+        season_data=_season_data("a-jellyfin"),
+    )
+    a_server2 = _series_data(
+        "Series A",
+        tmdb=1001,
+        tvdb="9002",
+        service=Service.PLEX,
+        season_data=_season_data("a-plex"),
+    )
+    b = _series_data("Series B", tmdb=1001, tvdb="9001")
+
+    unique, supplemental = _dedupe_aggregated_series([a_server1, a_server2, b])
+
+    assert unique[1001].name == "Series B"
+    assert supplemental == {}
+
+
+def test_missing_tvdb_on_one_side_still_merges() -> None:
+    """Only two present-and-different tvdb ids prove a genuine collision."""
+    a = _series_data("Series A", tmdb=1001, tvdb="9001")
+    b = _series_data("Series B", tmdb=1001, tvdb=None)
+
+    unique, supplemental = _dedupe_aggregated_series([a, b])
+
+    assert 1001 in supplemental
+    assert list(unique) == [1001]
+
+
+def test_series_without_a_tmdb_id_is_skipped() -> None:
+    unique, _ = _dedupe_aggregated_series(
+        [_series_data("Series A", tmdb=0, tvdb="9001")]
+    )
+
+    assert unique == {}


### PR DESCRIPTION
## Summary

Four defects in the media sync path, found after switching the main media server and
noticing the dashboard counts did not match the server's. All were confirmed against a
live instance using read-only database queries and read-only media-server API calls.

The unifying fault is that the sync identifies media by TMDB id in places where TMDB id
is not a reliable identity: it is not stable across media servers, and it is not unique
per show.

## 1. Soft-delete removed media that was still on the main server

This fires on the normal sync path, not just on a resync.

`sync_series` adds each incoming TMDB id to `parsed_tmdb_ids`, then resolves the existing
row by tmdb id, falling back to tvdb id and imdb id. A row found by fallback keeps its
own `tmdb_id`, which differs from the incoming one, so the delete pass tested the row's
own id, failed to find it, and tombstoned a row it had just updated from the main server.

Because tombstoned rows are reloaded on the next run, the row was then restored and
deleted again on every subsequent sync. The affected media stays invisible to the app:
not scanned as a candidate, not protectable, absent from the UI. `sync_movies` had the
same shape through its imdb fallback.

Fixed by tracking which database rows the sync touched, rather than which TMDB ids the
server reported. Reassigning `tmdb_id` on the matched row was considered and rejected:
every identity column involved is `unique=True`, so reassignment can raise an
IntegrityError in exactly the collision case the fallback exists to handle.

## 2. `sync_series` had no main-server resolution

`sync_movies` resolves the main server when called with no service argument, and returns
early for a linked server. `sync_series` did neither, so `gather_series(None)` fell
through to every enabled media server.

The normal sync path was unaffected because it passes the main server explicitly. Only
`resync_media`, which calls `sync_series()` with no argument, was affected: it gathered
series from the main server plus every linked one, and the series table became the union,
with rows keyed by ids the main server never reports. Fixed by giving `sync_series` the
same resolution and guard `sync_movies` already had.

## 3. Soft-delete destroyed protections that nothing can rebuild

When media is soft-deleted the row survives as a tombstone and is restored if the media
reappears. But the cleanup hard-deleted the medium's `ReclaimCandidate`, `ProtectedMedia`
and `ProtectionRequest` rows, so a person's decision was gone permanently and did not
return with the restored row.

Now only rows the system can rebuild are deleted: candidates (regenerated by the reclaim
scan) and rule-sourced protections (regenerated by the rule task). Manual protections and
protection requests survive.

Because a protection can now outlive the media it points at, the two protected-list
endpoints and the two protection-request endpoints filter on the media still being live,
and `approve_request` refuses a request whose media has been removed rather than
succeeding into a protection that is then hidden. Those filters are no-ops against
existing data, since the rows they exclude could not previously exist.

## 4. Two distinct series sharing a TMDB id were merged

The series dedup exists for one series reported more than once: keep one entry, stash the
loser's season data as supplemental so its episode ids still reach the episodes table.

It also caught two genuinely different series sharing a TMDB umbrella entry. That merge
writes the loser's media-server episode ids onto the winner's episode rows, so a surviving
series' episodes reference another series' files. Two present and differing TVDB ids
identify the real case, so it is now logged and discarded rather than merged.

Ownership of the surviving row also follows the lower TVDB id now, rather than watch
dates. Previously, watching the other series flipped which one owned the row on the next
sync, and since the row's `title` is never reassigned on update, the row kept displaying
one series' name while its size, seasons and episodes silently became the other's.

## New behaviour worth reviewing: a soft-delete sanity guard

A partial media-server response makes the incoming set look small, and everything missing
from it is tombstoned. During diagnosis a library sync returned a 500 and succeeded again
seconds later, so this is not hypothetical.

The delete pass is now skipped when a library of at least 20 live items would lose more
than half of them. Because a legitimate main-server switch looks identical to a partial
response by that measure, the guard is two-strikes: it remembers the proposed delete set
and applies it if the next sync proposes exactly the same one. A flapping server proposes
a different set each time and stays blocked; a real reduction goes through on the second
sync. The state is process-local, so a restart costs one extra grace run.

Thresholds are module constants rather than settings, to keep the configuration surface
unchanged. Happy to expose them if you would prefer.

## Existing databases

No migration. Each symptom converges on the next normal sync, except a large reduction,
which needs two by design of the guard above:

- Tombstoned-but-live media is matched by the fallback, restored, and no longer
  re-deleted.
- Rows keyed by a linked server's TMDB ids stop appearing in any incoming set once the
  resync is main-only, so the delete pass tombstones them. They are phantoms and that is
  the correct outcome.

## Sequencing

`resync_media` still passes `allow_soft_delete=False` for both movies and series, so a
main-server switch leaves the old server's library live and the counts remain a union of
both. I have deliberately left that alone here.

It is the natural follow-up, but it is only safe once this lands: turning the delete pass
back on while any of the above is outstanding would run a delete that targets the wrong
rows, over a set inflated by linked servers, while destroying protections. The
`RESYNC_MEDIA` task description in `scheduler.py` also claims it "deletes and re-adds all
media", which does not match what it currently does. Happy to open that as a second PR
once you have looked at this one.

## Limitations

**Two series sharing a TMDB id still cannot both be stored or displayed.** The change
above stops the merge corrupting the surviving row, settles which series owns it, and
makes the collision visible in the logs. It does not make the second series
representable: only one row can exist per TMDB id, so the other stays absent from the UI,
candidates and protections, with only a log line to explain it.

Storing both would mean dropping `unique=True` from `Series.tmdb_id`, and the constraint
is relied on well beyond the schema: roughly 20 `Series.tmdb_id` query sites across 11
backend files, around seven TMDB-keyed dicts that silently collapse duplicates rather
than failing, six frontend files, and the external v1 API, which resolves a series *by*
TMDB id to create a protection and so would need a version bump. That is a schema
migration, a sync rewrite and an API change, which is your call rather than something
this PR is asking for. Mentioning the scale so it can be weighed rather than discovered.

**Which of the two survives is arbitrary.** The lower TVDB id is stable but carries no
meaning, and an instance cannot choose the other one. That only becomes meaningful
alongside the refactor above.

**A protection request for removed media is now invisible but not resolved.** It no
longer appears in either list and can no longer be approved, but it stays PENDING. There
is no path to reject it, which would need a sweep task; I did not want to add one
unasked.

**The dashboard's pending-request count has no liveness filter,** so a badge can exceed
the list it links to. This matches the existing behaviour for protected media rather than
being new, so I left both alone rather than widening the change.

## Testing

572 tests pass, up from 527 on `dev`. New coverage: the fallback-matched row surviving the delete
pass, the guard's ratio, floor and two-strikes behaviour, protections and requests
surviving a tombstone and being restored with the row, the read-side filters on all four
endpoints, the linked-server guard, the collision discriminator, and the stable winner.

Two behaviours are pinned by mutation testing rather than assertion alone, because both
would otherwise pass a plausible-looking test: that the collision path does not inherit
a displaced series' supplemental stash, and that `sync_series(main_server)` still performs
a full sync.

## A note on tooling

`[tool.ruff] include` in `pyproject.toml` covers `backend/core`, `backend/api`,
`backend/services`, `desktop` and `scripts`, but not `backend/tasks` or `tests`. So
`ruff check .` and `ruff format --check .` (the commands in the contributing guide, and
the ones CI runs) do not inspect those paths and report success regardless. I verified
this branch by passing explicit file paths. Flagging it because it silently affects
anything under `backend/tasks`, not just this change.
