### PR TITLE
Validate rating field values in the advanced rule engine

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,32 @@
+name: Python Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches:
+      - "**"
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --group dev --extra desktop --frozen
+
+      - name: Run pytest
+        run: uv run pytest

--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -310,6 +310,9 @@ NUMERIC_FIELDS = {
 }
 
 # field -> (minimum, maximum or None, integer required)
+# Mirrored by NUMERIC_FIELD_BOUNDS in
+# frontend/src/lib/components/settings/rules/rule-node-editor.svelte.
+# tests/test_rule_engine_frontend_parity.py fails if the two drift.
 FIELD_NUMERIC_BOUNDS: dict[str, tuple[float, float | None, bool]] = {
     # 0-10 scales, decimals allowed
     "tmdb.vote_average": (0, 10, False),
@@ -1645,7 +1648,7 @@ def _validate_numeric_bounds(field: str, operator: str, value: Any) -> None:
     if field not in FIELD_NUMERIC_BOUNDS:
         return
 
-    _minimum, _maximum, integer_required = FIELD_NUMERIC_BOUNDS[field]
+    minimum, maximum, integer_required = FIELD_NUMERIC_BOUNDS[field]
     label = FIELD_LABELS.get(field, field)
 
     if isinstance(value, list):
@@ -1655,28 +1658,28 @@ def _validate_numeric_bounds(field: str, operator: str, value: Any) -> None:
         )
     # bool is a subclass of int, and float(True) is 1.0, so guard it explicitly
     if isinstance(value, bool):
-        raise ValueError(f"{label} expects a number")
+        raise ValueError(_numeric_expectation(field))
 
     number = _number(value)
     if number is None or not math.isfinite(number):
-        raise ValueError(f"{label} expects a number")
+        raise ValueError(_numeric_expectation(field))
 
-    if number < _minimum or (_maximum is not None and number > _maximum):
+    if number < minimum or (maximum is not None and number > maximum):
         raise ValueError(_numeric_expectation(field))
     if integer_required and not float(number).is_integer():
         raise ValueError(_numeric_expectation(field))
 
     operator_label = OPERATOR_LABELS.get(operator, operator)
-    if _maximum is not None and operator == "greater_than" and number == _maximum:
+    if maximum is not None and operator == "greater_than" and number == maximum:
         raise ValueError(
             f"{label} {operator_label} {_format_bound(number)} can never match; "
-            f"{_format_bound(_maximum)} is the maximum "
+            f"{_format_bound(maximum)} is the maximum "
             f"(use {OPERATOR_LABELS['greater_than_or_equal']} to include it)"
         )
-    if operator == "less_than" and number == _minimum:
+    if operator == "less_than" and number == minimum:
         raise ValueError(
             f"{label} {operator_label} {_format_bound(number)} can never match; "
-            f"{_format_bound(_minimum)} is the minimum "
+            f"{_format_bound(minimum)} is the minimum "
             f"(use {OPERATOR_LABELS['less_than_or_equal']} to include it)"
         )
 

--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -1666,6 +1666,20 @@ def _validate_numeric_bounds(field: str, operator: str, value: Any) -> None:
     if integer_required and not float(number).is_integer():
         raise ValueError(_numeric_expectation(field))
 
+    operator_label = OPERATOR_LABELS.get(operator, operator)
+    if _maximum is not None and operator == "greater_than" and number == _maximum:
+        raise ValueError(
+            f"{label} {operator_label} {_format_bound(number)} can never match; "
+            f"{_format_bound(_maximum)} is the maximum "
+            f"(use {OPERATOR_LABELS['greater_than_or_equal']} to include it)"
+        )
+    if operator == "less_than" and number == _minimum:
+        raise ValueError(
+            f"{label} {operator_label} {_format_bound(number)} can never match; "
+            f"{_format_bound(_minimum)} is the minimum "
+            f"(use {OPERATOR_LABELS['less_than_or_equal']} to include it)"
+        )
+
 
 def _validate_node(node: dict[str, Any]) -> None:
     """Validate the structure and content of a rule node."""

--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 import shutil
 from collections.abc import Iterable, Iterator, Mapping
@@ -1614,6 +1615,58 @@ def _validate_scope_fields(definition: RuleDefinition, target_scope: str) -> Non
         )
 
 
+def _format_bound(value: float) -> str:
+    """Render a bound without a trailing .0 so messages read naturally."""
+    return str(int(value)) if float(value).is_integer() else str(value)
+
+
+def _numeric_expectation(field: str) -> str:
+    """Build the human-readable expectation for a bounded numeric field."""
+    minimum, maximum, integer_required = FIELD_NUMERIC_BOUNDS[field]
+    label = FIELD_LABELS.get(field, field)
+    kind = "a whole number" if integer_required else "a value"
+    if maximum is None:
+        expectation = f"{label} expects {kind} of {_format_bound(minimum)} or greater"
+    else:
+        expectation = (
+            f"{label} expects {kind} between "
+            f"{_format_bound(minimum)} and {_format_bound(maximum)}"
+        )
+    note = RESCALED_FIELD_NOTES.get(field)
+    return f"{expectation} ({note})" if note else expectation
+
+
+def _validate_numeric_bounds(field: str, operator: str, value: Any) -> None:
+    """Reject values that are out of range, the wrong type, or non-finite.
+
+    Only applies to fields listed in FIELD_NUMERIC_BOUNDS. Callers must skip
+    valueless operators, which carry no value to check.
+    """
+    if field not in FIELD_NUMERIC_BOUNDS:
+        return
+
+    _minimum, _maximum, integer_required = FIELD_NUMERIC_BOUNDS[field]
+    label = FIELD_LABELS.get(field, field)
+
+    if isinstance(value, list):
+        raise ValueError(
+            f"{label} expects a single value, not a list. "
+            "Only the first entry would be used."
+        )
+    # bool is a subclass of int, and float(True) is 1.0, so guard it explicitly
+    if isinstance(value, bool):
+        raise ValueError(f"{label} expects a number")
+
+    number = _number(value)
+    if number is None or not math.isfinite(number):
+        raise ValueError(f"{label} expects a number")
+
+    if number < _minimum or (_maximum is not None and number > _maximum):
+        raise ValueError(_numeric_expectation(field))
+    if integer_required and not float(number).is_integer():
+        raise ValueError(_numeric_expectation(field))
+
+
 def _validate_node(node: dict[str, Any]) -> None:
     """Validate the structure and content of a rule node."""
     node_type = node.get("type")
@@ -1645,6 +1698,8 @@ def _validate_node(node: dict[str, Any]) -> None:
         raise ValueError(f"Unsupported rule operator '{operator}' for field '{field}'")
     if operator not in VALUELESS_OPERATORS and "value" not in node:
         raise ValueError("Rule condition requires a value")
+    if operator not in VALUELESS_OPERATORS:
+        _validate_numeric_bounds(field, operator, node.get("value"))
     if field == "library.id" and operator in LIST_OPERATORS:
         raw_values = node.get("value")
         values = raw_values if isinstance(raw_values, list) else [raw_values]

--- a/backend/core/rule_engine.py
+++ b/backend/core/rule_engine.py
@@ -307,6 +307,46 @@ NUMERIC_FIELDS = {
     "disk.free_bytes",
     "disk.free_percent",
 }
+
+# field -> (minimum, maximum or None, integer required)
+FIELD_NUMERIC_BOUNDS: dict[str, tuple[float, float | None, bool]] = {
+    # 0-10 scales, decimals allowed
+    "tmdb.vote_average": (0, 10, False),
+    "imdb.rating": (0, 10, False),
+    "media_server.user_rating": (0, 10, False),
+    # 0-100 scales, whole numbers only
+    "rottentomatoes.tomato_meter": (0, 100, True),
+    "rottentomatoes.popcorn_meter": (0, 100, True),
+    "metacritic.metascore": (0, 100, True),
+    "metacritic.user_score": (0, 100, True),
+    "trakt.rating": (0, 100, True),
+    "letterboxd.score": (0, 100, True),
+    "anilist.score": (0, 100, True),
+    # counts, no upper bound
+    "tmdb.vote_count": (0, None, True),
+    "imdb.vote_count": (0, None, True),
+    "rottentomatoes.tomato_vote_count": (0, None, True),
+    "rottentomatoes.popcorn_vote_count": (0, None, True),
+    "metacritic.vote_count": (0, None, True),
+    "metacritic.user_vote_count": (0, None, True),
+    "trakt.vote_count": (0, None, True),
+    "letterboxd.vote_count": (0, None, True),
+    "anilist.popularity": (0, None, True),
+    "anilist.favourites": (0, None, True),
+}
+
+# Fields whose stored scale differs from the scale the provider publishes.
+# Surfaced in validation errors so the user is not left comparing our message
+# against a different number on the provider's own site.
+RESCALED_FIELD_NOTES: dict[str, str] = {
+    "metacritic.user_score": (
+        "Metacritic publishes this as 0-10; Reclaimerr stores it as a percentage"
+    ),
+    "letterboxd.score": (
+        "Letterboxd publishes this as 0-5; Reclaimerr stores it as a percentage"
+    ),
+}
+
 TEXT_FIELDS = {
     "tmdb.collection_name",
     "tmdb.genres",

--- a/docs/usage/rules.md
+++ b/docs/usage/rules.md
@@ -277,6 +277,12 @@ Rotten Tomatoes, Metacritic, Trakt, and Letterboxd plus vote counts. OMDb is
 used as a fallback for Tomatometer and Metacritic when an IMDb ID is available.
 Direct Rotten Tomatoes and Metacritic scraping is intentionally not used.
 
+Metacritic user score and Letterboxd score are stored and matched on a 0-100
+scale, but the providers publish them differently: Metacritic shows its user
+score as 0-10 on its own site, and Letterboxd shows its score as 0-5. Build
+rules against the stored 0-100 value, not the number shown on the provider's
+site.
+
 Ratings are refreshed by the provider-specific `Refresh MDBList Ratings` and
 `Refresh OMDb Ratings` tasks. They keep independent schedules and caches.
 MDBList values remain authoritative, while OMDb fills missing Tomatometer and

--- a/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
+++ b/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
@@ -1554,8 +1554,37 @@
     SCOPE_FIELD_VALUES[targetScope].has(fieldValue);
   const operatorLabel = (value: RuleConditionOperator) =>
     operatorLabelMap[value] ?? value;
+  // Mirrors FIELD_NUMERIC_BOUNDS in backend/core/rule_engine.py.
+  // tests/test_rule_engine_frontend_parity.py fails if the two drift.
+  const NUMERIC_FIELD_BOUNDS: Record<
+    string,
+    { min: number; max: number | null; step: "1" | "any" }
+  > = {
+    "tmdb.vote_average": { min: 0, max: 10, step: "any" },
+    "imdb.rating": { min: 0, max: 10, step: "any" },
+    "media_server.user_rating": { min: 0, max: 10, step: "any" },
+    "rottentomatoes.tomato_meter": { min: 0, max: 100, step: "1" },
+    "rottentomatoes.popcorn_meter": { min: 0, max: 100, step: "1" },
+    "metacritic.metascore": { min: 0, max: 100, step: "1" },
+    "metacritic.user_score": { min: 0, max: 100, step: "1" },
+    "trakt.rating": { min: 0, max: 100, step: "1" },
+    "letterboxd.score": { min: 0, max: 100, step: "1" },
+    "anilist.score": { min: 0, max: 100, step: "1" },
+    "tmdb.vote_count": { min: 0, max: null, step: "1" },
+    "imdb.vote_count": { min: 0, max: null, step: "1" },
+    "rottentomatoes.tomato_vote_count": { min: 0, max: null, step: "1" },
+    "rottentomatoes.popcorn_vote_count": { min: 0, max: null, step: "1" },
+    "metacritic.vote_count": { min: 0, max: null, step: "1" },
+    "metacritic.user_vote_count": { min: 0, max: null, step: "1" },
+    "trakt.vote_count": { min: 0, max: null, step: "1" },
+    "letterboxd.vote_count": { min: 0, max: null, step: "1" },
+    "anilist.popularity": { min: 0, max: null, step: "1" },
+    "anilist.favourites": { min: 0, max: null, step: "1" },
+  };
   const isNumericInput = (c: RuleCondition) =>
     fieldConfig(c.field).kind === "number" && !listOperators.has(c.operator);
+  const numericBoundsFor = (c: RuleCondition) =>
+    isNumericInput(c) ? NUMERIC_FIELD_BOUNDS[c.field] : undefined;
   const isByteInput = (c: RuleCondition) =>
     fieldConfig(c.field).kind === "bytes" && !listOperators.has(c.operator);
   const isTemporalInput = (c: RuleCondition) =>
@@ -2212,6 +2241,9 @@
                 : isTemporalInput(node)
                   ? "date"
                   : "text"}
+              min={numericBoundsFor(node)?.min}
+              max={numericBoundsFor(node)?.max ?? undefined}
+              step={numericBoundsFor(node)?.step}
               placeholder={valuePlaceholder(node)}
               value={valueText(node)}
               oninput={(e) => setConditionValue(node, e.currentTarget.value)}

--- a/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
+++ b/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
@@ -1581,6 +1581,11 @@
     "anilist.popularity": { min: 0, max: null, step: "1" },
     "anilist.favourites": { min: 0, max: null, step: "1" },
   };
+  // The two fields where following the provider's own site gives a wrong value.
+  const RESCALED_FIELD_HINTS: Record<string, string> = {
+    "metacritic.user_score": "0-100 (Metacritic shows this as 0-10)",
+    "letterboxd.score": "0-100 (Letterboxd shows this as 0-5)",
+  };
   const isNumericInput = (c: RuleCondition) =>
     fieldConfig(c.field).kind === "number" && !listOperators.has(c.operator);
   const numericBoundsFor = (c: RuleCondition) =>
@@ -1609,6 +1614,14 @@
       return "Country codes (for example: US, GB)...";
     if (c.field === "media_server.collections")
       return "Media-server collections (comma-separated)...";
+    const bounds = numericBoundsFor(c);
+    if (bounds) {
+      const hint = RESCALED_FIELD_HINTS[c.field];
+      if (hint) return hint;
+      return bounds.max === null
+        ? `${bounds.min} or more…`
+        : `${bounds.min}-${bounds.max}`;
+    }
     if (listOperators.has(c.operator)) return "comma-separated…";
     return "value…";
   };

--- a/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
+++ b/frontend/src/lib/components/settings/rules/rule-node-editor.svelte
@@ -1620,7 +1620,7 @@
       if (hint) return hint;
       return bounds.max === null
         ? `${bounds.min} or more…`
-        : `${bounds.min}-${bounds.max}`;
+        : `${bounds.min}-${bounds.max}…`;
     }
     if (listOperators.has(c.operator)) return "comma-separated…";
     return "value…";

--- a/tests/test_rule_engine_frontend_parity.py
+++ b/tests/test_rule_engine_frontend_parity.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from backend.core.rule_engine import FIELD_NUMERIC_BOUNDS
+
+EDITOR = (
+    Path(__file__).resolve().parents[1]
+    / "frontend"
+    / "src"
+    / "lib"
+    / "components"
+    / "settings"
+    / "rules"
+    / "rule-node-editor.svelte"
+)
+
+ENTRY = re.compile(
+    r'"(?P<field>[^"]+)":\s*\{\s*'
+    r"min:\s*(?P<min>-?\d+(?:\.\d+)?),\s*"
+    r"max:\s*(?P<max>null|-?\d+(?:\.\d+)?),\s*"
+    r'step:\s*"(?P<step>1|any)"\s*\}'
+)
+
+
+def _frontend_bounds() -> dict[str, tuple[float, float | None, bool]]:
+    source = EDITOR.read_text(encoding="utf-8")
+    start = source.index("const NUMERIC_FIELD_BOUNDS")
+    end = source.index("};", start)
+    block = source[start:end]
+    bounds: dict[str, tuple[float, float | None, bool]] = {}
+    for match in ENTRY.finditer(block):
+        maximum = None if match["max"] == "null" else float(match["max"])
+        bounds[match["field"]] = (
+            float(match["min"]),
+            maximum,
+            match["step"] == "1",
+        )
+    return bounds
+
+
+class FrontendBoundsParityTests(unittest.TestCase):
+    def test_editor_file_exists(self) -> None:
+        self.assertTrue(EDITOR.is_file(), f"missing {EDITOR}")
+
+    def test_frontend_block_parses(self) -> None:
+        self.assertTrue(
+            _frontend_bounds(),
+            "parsed no entries from NUMERIC_FIELD_BOUNDS; the map's formatting "
+            "changed and this test's regex needs updating",
+        )
+
+    def test_frontend_and_backend_bounds_match(self) -> None:
+        self.assertEqual(_frontend_bounds(), dict(FIELD_NUMERIC_BOUNDS))

--- a/tests/test_rule_engine_validation.py
+++ b/tests/test_rule_engine_validation.py
@@ -1006,6 +1006,44 @@ class NumericBoundsValidationTests(unittest.TestCase):
         self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", 80)
         self._validate("imdb.vote_count", "greater_than_or_equal", 5000)
 
+
+class NumericBoundaryImpossibilityTests(unittest.TestCase):
+    def _validate(self, field: str, operator: str, value: object) -> None:
+        validate_rule_definition(
+            _definition(field, operator, value),
+            target_scope=TARGET_MOVIE_VERSION,
+        )
+
+    def test_greater_than_maximum_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("rottentomatoes.tomato_meter", "greater_than", 100)
+        message = str(ctx.exception)
+        self.assertIn("can never match", message)
+        self.assertIn("100 is the maximum", message)
+
+    def test_greater_than_or_equal_maximum_is_accepted(self) -> None:
+        self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", 100)
+
+    def test_less_than_minimum_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("imdb.vote_count", "less_than", 0)
+        message = str(ctx.exception)
+        self.assertIn("can never match", message)
+        self.assertIn("0 is the minimum", message)
+
+    def test_less_than_or_equal_minimum_is_accepted(self) -> None:
+        self._validate("imdb.vote_count", "less_than_or_equal", 0)
+
+    def test_unbounded_field_allows_large_greater_than(self) -> None:
+        self._validate("imdb.vote_count", "greater_than", 5_000_000)
+
+    def test_boundary_message_uses_operator_symbols(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("imdb.rating", "greater_than", 10)
+        message = str(ctx.exception)
+        self.assertIn("IMDb rating > 10", message)
+        self.assertIn("use >=", message)
+
     def test_value_above_maximum_is_rejected(self) -> None:
         with self.assertRaises(ValueError) as ctx:
             self._validate("imdb.rating", "greater_than_or_equal", 11)

--- a/tests/test_rule_engine_validation.py
+++ b/tests/test_rule_engine_validation.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import unittest
 
 from backend.core.rule_engine import (
+    FIELD_LABELS,
+    FIELD_NUMERIC_BOUNDS,
+    NUMERIC_FIELDS,
+    RESCALED_FIELD_NOTES,
     RULE_VALUE_UNAVAILABLE,
     TARGET_EPISODE,
     TARGET_MOVIE_VERSION,
@@ -950,6 +954,44 @@ class ArrTagRegexOperatorTests(unittest.TestCase):
                 ["tag-1-stale"], "matches_any_regex", ["[invalid"], field="arr.tags"
             )
         )
+
+
+class NumericBoundsTableTests(unittest.TestCase):
+    def test_every_bounded_field_is_a_known_numeric_field(self) -> None:
+        for field in FIELD_NUMERIC_BOUNDS:
+            self.assertIn(field, NUMERIC_FIELDS, f"{field} is not a numeric field")
+            self.assertIn(field, FIELD_LABELS, f"{field} has no display label")
+
+    def test_bounds_are_internally_consistent(self) -> None:
+        for field, (minimum, maximum, integer_required) in FIELD_NUMERIC_BOUNDS.items():
+            self.assertGreaterEqual(minimum, 0, f"{field} has a negative minimum")
+            if maximum is not None:
+                self.assertGreater(maximum, minimum, f"{field} has max <= min")
+            self.assertIsInstance(integer_required, bool)
+
+    def test_rating_scales_are_grouped_as_specified(self) -> None:
+        ten_point = {"tmdb.vote_average", "imdb.rating", "media_server.user_rating"}
+        hundred_point = {
+            "rottentomatoes.tomato_meter",
+            "rottentomatoes.popcorn_meter",
+            "metacritic.metascore",
+            "metacritic.user_score",
+            "trakt.rating",
+            "letterboxd.score",
+            "anilist.score",
+        }
+        for field in ten_point & set(FIELD_NUMERIC_BOUNDS):
+            self.assertEqual(FIELD_NUMERIC_BOUNDS[field], (0, 10, False), field)
+        for field in hundred_point:
+            self.assertEqual(FIELD_NUMERIC_BOUNDS[field], (0, 100, True), field)
+
+    def test_rescaled_fields_have_notes(self) -> None:
+        self.assertEqual(
+            set(RESCALED_FIELD_NOTES),
+            {"metacritic.user_score", "letterboxd.score"},
+        )
+        for note in RESCALED_FIELD_NOTES.values():
+            self.assertIn("Reclaimerr stores it as a percentage", note)
 
 
 if __name__ == "__main__":

--- a/tests/test_rule_engine_validation.py
+++ b/tests/test_rule_engine_validation.py
@@ -994,5 +994,77 @@ class NumericBoundsTableTests(unittest.TestCase):
             self.assertIn("Reclaimerr stores it as a percentage", note)
 
 
+class NumericBoundsValidationTests(unittest.TestCase):
+    def _validate(self, field: str, operator: str, value: object) -> None:
+        validate_rule_definition(
+            _definition(field, operator, value),
+            target_scope=TARGET_MOVIE_VERSION,
+        )
+
+    def test_in_range_values_are_accepted(self) -> None:
+        self._validate("imdb.rating", "greater_than_or_equal", 7.5)
+        self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", 80)
+        self._validate("imdb.vote_count", "greater_than_or_equal", 5000)
+
+    def test_value_above_maximum_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("imdb.rating", "greater_than_or_equal", 11)
+        self.assertIn("between 0 and 10", str(ctx.exception))
+
+        with self.assertRaises(ValueError):
+            self._validate("rottentomatoes.tomato_meter", "less_than", 101)
+
+    def test_negative_values_are_rejected(self) -> None:
+        for field in ("imdb.rating", "rottentomatoes.tomato_meter", "imdb.vote_count"):
+            with self.assertRaises(ValueError):
+                self._validate(field, "greater_than_or_equal", -1)
+
+    def test_decimals_rejected_on_integer_fields_but_allowed_on_rating_fields(
+        self,
+    ) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("rottentomatoes.tomato_meter", "equals", 78.5)
+        self.assertIn("whole number", str(ctx.exception))
+        self._validate("imdb.rating", "greater_than_or_equal", 7.25)
+
+    def test_list_values_are_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("imdb.rating", "greater_than_or_equal", [7, 8])
+        self.assertIn("single value", str(ctx.exception))
+
+    def test_booleans_are_rejected_and_not_read_as_one(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate("imdb.rating", "greater_than_or_equal", True)
+
+    def test_numeric_strings_are_accepted(self) -> None:
+        self._validate("imdb.rating", "greater_than_or_equal", "7.5")
+        self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", "80")
+
+    def test_non_numeric_and_non_finite_values_are_rejected(self) -> None:
+        for value in ("high", "inf", "nan"):
+            with self.assertRaises(ValueError):
+                self._validate("imdb.rating", "greater_than_or_equal", value)
+
+    def test_valueless_operators_still_validate(self) -> None:
+        self._validate("imdb.rating", "exists", None)
+        self._validate("rottentomatoes.tomato_meter", "not_exists", None)
+
+    def test_error_uses_display_label_not_field_key(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", 101)
+        message = str(ctx.exception)
+        self.assertIn("Rotten Tomatoes Tomatometer", message)
+        self.assertNotIn("rottentomatoes.tomato_meter", message)
+
+    def test_rescaled_fields_explain_the_provider_scale(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("metacritic.user_score", "greater_than_or_equal", 101)
+        self.assertIn("Metacritic publishes this as 0-10", str(ctx.exception))
+
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("letterboxd.score", "greater_than_or_equal", 101)
+        self.assertIn("Letterboxd publishes this as 0-5", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rule_engine_validation.py
+++ b/tests/test_rule_engine_validation.py
@@ -1006,44 +1006,6 @@ class NumericBoundsValidationTests(unittest.TestCase):
         self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", 80)
         self._validate("imdb.vote_count", "greater_than_or_equal", 5000)
 
-
-class NumericBoundaryImpossibilityTests(unittest.TestCase):
-    def _validate(self, field: str, operator: str, value: object) -> None:
-        validate_rule_definition(
-            _definition(field, operator, value),
-            target_scope=TARGET_MOVIE_VERSION,
-        )
-
-    def test_greater_than_maximum_is_rejected(self) -> None:
-        with self.assertRaises(ValueError) as ctx:
-            self._validate("rottentomatoes.tomato_meter", "greater_than", 100)
-        message = str(ctx.exception)
-        self.assertIn("can never match", message)
-        self.assertIn("100 is the maximum", message)
-
-    def test_greater_than_or_equal_maximum_is_accepted(self) -> None:
-        self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", 100)
-
-    def test_less_than_minimum_is_rejected(self) -> None:
-        with self.assertRaises(ValueError) as ctx:
-            self._validate("imdb.vote_count", "less_than", 0)
-        message = str(ctx.exception)
-        self.assertIn("can never match", message)
-        self.assertIn("0 is the minimum", message)
-
-    def test_less_than_or_equal_minimum_is_accepted(self) -> None:
-        self._validate("imdb.vote_count", "less_than_or_equal", 0)
-
-    def test_unbounded_field_allows_large_greater_than(self) -> None:
-        self._validate("imdb.vote_count", "greater_than", 5_000_000)
-
-    def test_boundary_message_uses_operator_symbols(self) -> None:
-        with self.assertRaises(ValueError) as ctx:
-            self._validate("imdb.rating", "greater_than", 10)
-        message = str(ctx.exception)
-        self.assertIn("IMDb rating > 10", message)
-        self.assertIn("use >=", message)
-
     def test_value_above_maximum_is_rejected(self) -> None:
         with self.assertRaises(ValueError) as ctx:
             self._validate("imdb.rating", "greater_than_or_equal", 11)
@@ -1102,6 +1064,44 @@ class NumericBoundaryImpossibilityTests(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             self._validate("letterboxd.score", "greater_than_or_equal", 101)
         self.assertIn("Letterboxd publishes this as 0-5", str(ctx.exception))
+
+
+class NumericBoundaryImpossibilityTests(unittest.TestCase):
+    def _validate(self, field: str, operator: str, value: object) -> None:
+        validate_rule_definition(
+            _definition(field, operator, value),
+            target_scope=TARGET_MOVIE_VERSION,
+        )
+
+    def test_greater_than_maximum_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("rottentomatoes.tomato_meter", "greater_than", 100)
+        message = str(ctx.exception)
+        self.assertIn("can never match", message)
+        self.assertIn("100 is the maximum", message)
+
+    def test_greater_than_or_equal_maximum_is_accepted(self) -> None:
+        self._validate("rottentomatoes.tomato_meter", "greater_than_or_equal", 100)
+
+    def test_less_than_minimum_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("imdb.vote_count", "less_than", 0)
+        message = str(ctx.exception)
+        self.assertIn("can never match", message)
+        self.assertIn("0 is the minimum", message)
+
+    def test_less_than_or_equal_minimum_is_accepted(self) -> None:
+        self._validate("imdb.vote_count", "less_than_or_equal", 0)
+
+    def test_unbounded_field_allows_large_greater_than(self) -> None:
+        self._validate("imdb.vote_count", "greater_than", 5_000_000)
+
+    def test_boundary_message_uses_operator_symbols(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            self._validate("imdb.rating", "greater_than", 10)
+        message = str(ctx.exception)
+        self.assertIn("IMDb rating > 10", message)
+        self.assertIn("use >=", message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Rule conditions on external rating fields accept any number. `_validate_node` checks the field, the operator, and whether a value is present, but never the value itself. A threshold on the wrong scale saves without complaint and then matches nothing.

Two things make that easy to hit:

- The fields are not on one scale. IMDb rating is 0-10; Tomatometer is 0-100.
- Metacritic user score and Letterboxd score are stored as percentages, while those sites publish 0-10 and 0-5. Entering the published number gives a rule that can never match.

The failure is silent either way, and for a protect-outcome rule it fails open: the item simply is not protected.

## Changes

- A bounds table recording the range, integer requirement and provider-scale notes for every rating and vote-count field.
- Save-time validation rejecting out-of-range values, decimals on integer-backed fields, lists, booleans and non-finite values.
- Rejection of the two in-range combinations that can never match: `> maximum` and `< minimum`. The inclusive variants stay valid, since items do sit on both bounds.
- Errors report the field's display label and the operator symbol, and explain the two rescaled scales.
- The editor's number input now carries `min`, `max` and `step`, and the placeholder states the expected range.
- A note in the rules documentation covering the two rescaled scales.
- A test pinning the editor's bounds to the backend table.

## A note on the CI addition

This includes `.github/workflows/pytest.yml`, which runs the Python suite on pull requests. Flagging it explicitly rather than leaving it among the validation commits, since it touches automation rather than the rule engine.

No job currently runs pytest. That matters here specifically because the bounds are deliberately duplicated, once in Python and once in the editor's TypeScript, and `tests/test_rule_engine_frontend_parity.py` is the only thing stopping the two from drifting apart. Without a CI job it protects only whoever remembers to run the suite locally.

The workflow mirrors `typecheck.yml` exactly, same action versions, same Python version, same `uv sync` line, with `uv run pytest` as the only differing step. No matrix, no caching, no coverage tooling. If you would rather not take it, dropping that one commit leaves the rest of the PR intact.

## Compatibility

Validation runs on write only, so rules saved before this change keep evaluating exactly as they do now and the error appears the next time one is edited. Worth noting that editing a rule's target scope revalidates its stored definition, so a pre-existing out-of-range condition would surface at that point too.

## Testing

`uv run pytest` passes at 601. `ruff check` and `ruff format --check` are clean, and `npm run check` reports 0 errors.

New coverage spans range, type, boundary and label behaviour. The parity test was verified to fail when the two tables were deliberately made to disagree, rather than only observed to pass.