### PR TITLE
Refresh arr tags for rules that match tags by pattern

### DIFF
--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -1287,12 +1287,19 @@ async def _refresh_arr_tags_for_rules(
 
     movie_tag_labels = _collect_arr_tag_labels(movie_rules)
     series_tag_labels = _collect_arr_tag_labels(series_rules)
+    movie_needs_full_refresh = _has_non_exact_arr_tag_condition(movie_rules)
+    series_needs_full_refresh = _has_non_exact_arr_tag_condition(series_rules)
 
-    if not movie_tag_labels and not series_tag_labels:
+    # A pattern condition cannot name the labels it will match, so the whole
+    # catalog is refreshed for that media type instead of a filtered subset.
+    movie_tags_wanted = bool(movie_tag_labels) or movie_needs_full_refresh
+    series_tags_wanted = bool(series_tag_labels) or series_needs_full_refresh
+
+    if not movie_tags_wanted and not series_tags_wanted:
         return
 
     #### radarr: refresh movie arr_tags for rule relevant labels ####
-    if movie_tag_labels:
+    if movie_tags_wanted:
         radarr_clients = service_manager.radarr_clients()
         if not radarr_clients and service_manager.radarr:
             radarr_clients = {0: service_manager.radarr}
@@ -1300,6 +1307,8 @@ async def _refresh_arr_tags_for_rules(
         if radarr_clients:
             # movie_id (DB) -> set of labels to add
             movie_label_additions: dict[int, set[str]] = {}
+            # every label actually refreshed, across all configs that succeeded
+            movie_refreshed_labels: set[str] = set()
             radarr_successful_config_ids: set[int] = set()
             radarr_failed_config_ids: set[int] = set()
 
@@ -1332,10 +1341,16 @@ async def _refresh_arr_tags_for_rules(
                     continue
 
                 radarr_successful_config_ids.add(config_id)
+                effective_labels = (
+                    _all_catalog_labels(tag_list)
+                    if movie_needs_full_refresh
+                    else movie_tag_labels
+                )
+                movie_refreshed_labels |= effective_labels
                 label_to_arr_ids = _collect_arr_item_ids_by_label(
                     items=all_movies,
                     tags=tag_list,
-                    wanted_labels=movie_tag_labels,
+                    wanted_labels=effective_labels,
                 )
                 arr_to_db = arr_to_db_by_config.get(config_id, {})
                 for label, arr_ids in label_to_arr_ids.items():
@@ -1365,19 +1380,19 @@ async def _refresh_arr_tags_for_rules(
                     )
                     for movie in result.scalars().all():
                         current = set(movie.arr_tags or [])
-                        current -= movie_tag_labels  # strip stale rule-relevant labels
+                        current -= movie_refreshed_labels  # strip refreshed labels
                         current |= movie_label_additions.get(
                             movie.id, set()
                         )  # re-add current ones
                         movie.arr_tags = sorted(current)
                     await db.commit()
-            elif movie_tag_labels and radarr_failed_config_ids:
+            elif movie_tags_wanted and radarr_failed_config_ids:
                 LOG.warning(
                     "Radarr tag refresh failed for all relevant refs; "
                     "keeping existing movie arr_tags rows unchanged"
                 )
             LOG.debug(
-                f"Refreshed arr_tags for {len(refreshable_db_movie_ids)} movies (labels: {movie_tag_labels})"
+                f"Refreshed arr_tags for {len(refreshable_db_movie_ids)} movies (labels: {movie_refreshed_labels})"
             )
 
     #### sonarr: refresh series arr_tags for rule relevant labels ####

--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -1402,12 +1402,14 @@ async def _refresh_arr_tags_for_rules(
             )
 
     #### sonarr: refresh series arr_tags for rule relevant labels ####
-    if series_tag_labels:
+    if series_tags_wanted:
         sonarr_series_snapshot = sonarr_series_snapshot or _SonarrSeriesSnapshot()
         sonarr_clients = sonarr_series_snapshot.clients
 
         if sonarr_clients:
             series_label_additions: dict[int, set[str]] = {}
+            # every label actually refreshed, across all configs that succeeded
+            series_refreshed_labels: set[str] = set()
             sonarr_successful_config_ids: set[int] = set()
             sonarr_failed_config_ids: set[int] = set()
 
@@ -1441,10 +1443,16 @@ async def _refresh_arr_tags_for_rules(
                     continue
 
                 sonarr_successful_config_ids.add(config_id)
+                effective_labels = (
+                    _all_catalog_labels(tag_list)
+                    if series_needs_full_refresh
+                    else series_tag_labels
+                )
+                series_refreshed_labels |= effective_labels
                 label_to_arr_ids = _collect_arr_item_ids_by_label(
                     items=all_series,
                     tags=tag_list,
-                    wanted_labels=series_tag_labels,
+                    wanted_labels=effective_labels,
                 )
                 arr_to_db = sonarr_arr_to_db_by_config.get(config_id, {})
                 for label, arr_ids in label_to_arr_ids.items():
@@ -1472,18 +1480,26 @@ async def _refresh_arr_tags_for_rules(
                         select(Series).where(Series.id.in_(refreshable_db_series_ids))
                     )
                     for series in result.scalars().all():
+                        confirmed = series_label_additions.get(series.id, set())
+                        if series_needs_full_refresh:
+                            # Every label the arrs report for this item is known, so the
+                            # row is replaced rather than patched. This also clears a
+                            # label whose tag was deleted from the catalog, which a strip
+                            # set derived from that catalog cannot name.
+                            series.arr_tags = sorted(confirmed)
+                            continue
                         current = set(series.arr_tags or [])
-                        current -= series_tag_labels
-                        current |= series_label_additions.get(series.id, set())
+                        current -= series_refreshed_labels
+                        current |= confirmed
                         series.arr_tags = sorted(current)
                     await db.commit()
-            elif series_tag_labels and sonarr_failed_config_ids:
+            elif series_tags_wanted and sonarr_failed_config_ids:
                 LOG.warning(
                     "Sonarr tag refresh failed for all relevant refs; "
                     "keeping existing series arr_tags rows unchanged"
                 )
             LOG.debug(
-                f"Refreshed arr_tags for {len(refreshable_db_series_ids)} series (labels: {series_tag_labels})"
+                f"Refreshed arr_tags for {len(refreshable_db_series_ids)} series (labels: {series_refreshed_labels})"
             )
 
 

--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -1379,11 +1379,17 @@ async def _refresh_arr_tags_for_rules(
                         select(Movie).where(Movie.id.in_(refreshable_db_movie_ids))
                     )
                     for movie in result.scalars().all():
+                        confirmed = movie_label_additions.get(movie.id, set())
+                        if movie_needs_full_refresh:
+                            # Every label the arrs report for this item is known, so the
+                            # row is replaced rather than patched. This also clears a
+                            # label whose tag was deleted from the catalog, which a strip
+                            # set derived from that catalog cannot name.
+                            movie.arr_tags = sorted(confirmed)
+                            continue
                         current = set(movie.arr_tags or [])
                         current -= movie_refreshed_labels  # strip refreshed labels
-                        current |= movie_label_additions.get(
-                            movie.id, set()
-                        )  # re-add current ones
+                        current |= confirmed  # re-add current ones
                         movie.arr_tags = sorted(current)
                     await db.commit()
             elif movie_tags_wanted and radarr_failed_config_ids:

--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -1270,11 +1270,18 @@ async def _refresh_arr_tags_for_rules(
 
     Steps:
     1. Collect the distinct tag labels used in arr.tags conditions across all rules.
+       A pattern condition (regex/substring) cannot name its labels ahead of time, so
+       its presence triggers a full refresh of the arr's whole tag catalog instead.
     2. Per arr client: fetch items + tag catalog and resolve tag IDs to labels.
     3. Map arr item IDs -> DB IDs via MovieArrRef / SeriesArrRef.
-    4. Strip rule-relevant labels only on refs for configs that refreshed successfully,
-       then re-add only where confirmed present.
-    Failed config fetches are non-destructive (existing DB tags are preserved).
+    4. Write the confirmed labels to each ref reachable from a successfully refreshed
+       config, in one of two modes:
+       - Full refresh (a pattern condition is present): replace arr_tags outright with
+         the confirmed labels, since every label the arrs report for the item is known.
+       - Exact-match only: patch arr_tags, stripping just the rule-relevant labels and
+         re-adding only the ones confirmed present, leaving unrelated labels alone.
+    Failed config fetches are non-destructive in both modes: a ref reachable from any
+    failed config is excluded from the write, so its existing DB tags are preserved.
     """
     movie_rules = [
         r for r in rules if normalize_rule_target(r) in {TARGET_MOVIE_VERSION}
@@ -1307,7 +1314,9 @@ async def _refresh_arr_tags_for_rules(
         if radarr_clients:
             # movie_id (DB) -> set of labels to add
             movie_label_additions: dict[int, set[str]] = {}
-            # every label actually refreshed, across all configs that succeeded
+            # Every label actually refreshed, across all configs that succeeded. Drives
+            # the exact-match strip and the debug log only; full-refresh mode replaces
+            # arr_tags with movie_label_additions instead.
             movie_refreshed_labels: set[str] = set()
             radarr_successful_config_ids: set[int] = set()
             radarr_failed_config_ids: set[int] = set()
@@ -1392,13 +1401,18 @@ async def _refresh_arr_tags_for_rules(
                         current |= confirmed  # re-add current ones
                         movie.arr_tags = sorted(current)
                     await db.commit()
-            elif movie_tags_wanted and radarr_failed_config_ids:
+            elif radarr_failed_config_ids:
                 LOG.warning(
                     "Radarr tag refresh failed for all relevant refs; "
                     "keeping existing movie arr_tags rows unchanged"
                 )
+            label_summary = (
+                f"{len(movie_refreshed_labels)} catalog labels"
+                if movie_needs_full_refresh
+                else f"labels: {movie_refreshed_labels}"
+            )
             LOG.debug(
-                f"Refreshed arr_tags for {len(refreshable_db_movie_ids)} movies (labels: {movie_refreshed_labels})"
+                f"Refreshed arr_tags for {len(refreshable_db_movie_ids)} movies ({label_summary})"
             )
 
     #### sonarr: refresh series arr_tags for rule relevant labels ####
@@ -1408,7 +1422,9 @@ async def _refresh_arr_tags_for_rules(
 
         if sonarr_clients:
             series_label_additions: dict[int, set[str]] = {}
-            # every label actually refreshed, across all configs that succeeded
+            # Every label actually refreshed, across all configs that succeeded. Drives
+            # the exact-match strip and the debug log only; full-refresh mode replaces
+            # arr_tags with series_label_additions instead.
             series_refreshed_labels: set[str] = set()
             sonarr_successful_config_ids: set[int] = set()
             sonarr_failed_config_ids: set[int] = set()
@@ -1493,13 +1509,18 @@ async def _refresh_arr_tags_for_rules(
                         current |= confirmed
                         series.arr_tags = sorted(current)
                     await db.commit()
-            elif series_tags_wanted and sonarr_failed_config_ids:
+            elif sonarr_failed_config_ids:
                 LOG.warning(
                     "Sonarr tag refresh failed for all relevant refs; "
                     "keeping existing series arr_tags rows unchanged"
                 )
+            label_summary = (
+                f"{len(series_refreshed_labels)} catalog labels"
+                if series_needs_full_refresh
+                else f"labels: {series_refreshed_labels}"
+            )
             LOG.debug(
-                f"Refreshed arr_tags for {len(refreshable_db_series_ids)} series (labels: {series_refreshed_labels})"
+                f"Refreshed arr_tags for {len(refreshable_db_series_ids)} series ({label_summary})"
             )
 
 

--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -20,10 +20,12 @@ from backend.core.rule_engine import (
     FAVORITES_RULE_FIELDS,
     PLAYBACK_RULE_FIELDS,
     RANK_RULE_FIELDS,
+    REGEX_OPERATORS,
     RULE_OUTCOME_CANDIDATE,
     RULE_OUTCOME_PROTECT,
     RULE_VALUE_UNAVAILABLE,
     SONARR_RULE_FIELDS,
+    TAG_SUBSTRING_OPERATORS,
     TARGET_EPISODE,
     TARGET_MOVIE_VERSION,
     TARGET_SEASON,
@@ -1158,16 +1160,58 @@ async def scan_cleanup_candidates() -> None:
                 raise
 
 
+# arr.tags operators that match against patterns rather than whole tag labels.
+# Their condition values are needles or regexes, never tag names, so they cannot
+# be resolved to specific labels before the arr's tag catalog has been fetched.
+NON_EXACT_ARR_TAG_OPERATORS = REGEX_OPERATORS | TAG_SUBSTRING_OPERATORS
+
+
 def _collect_arr_tag_labels(rules: list[ReclaimRule]) -> set[str]:
-    """Return the distinct lowercase tag labels referenced in arr.tags conditions across rules."""
+    """Return the distinct lowercase tag labels named by exact-match arr.tags conditions.
+
+    Values belonging to non-exact operators are patterns rather than labels, so they
+    are skipped here; _has_non_exact_arr_tag_condition reports their presence instead.
+    """
     labels: set[str] = set()
     for rule in rules:
         for condition in collect_rule_conditions(rule.definition, field="arr.tags"):
+            if condition.get("operator") in NON_EXACT_ARR_TAG_OPERATORS:
+                continue
             value = condition.get("value")
             values = value if isinstance(value, list) else [value]
             for v in values:
                 if v is not None and str(v).strip():
                     labels.add(str(v).strip().lower())
+    return labels
+
+
+def _has_non_exact_arr_tag_condition(rules: list[ReclaimRule]) -> bool:
+    """Return True when any arr.tags condition matches by pattern instead of by label.
+
+    Such a condition cannot be narrowed to specific tag names ahead of time, so the
+    refresh widens to the arr's whole tag catalog rather than a filtered subset.
+    """
+    for rule in rules:
+        for condition in collect_rule_conditions(rule.definition, field="arr.tags"):
+            if condition.get("operator") in NON_EXACT_ARR_TAG_OPERATORS:
+                return True
+    return False
+
+
+def _all_catalog_labels(tags: Sequence[Any]) -> set[str]:
+    """Return every non-blank lowercase label in an arr tag catalog.
+
+    Normalisation matches _collect_arr_item_ids_by_label so that the labels used for
+    lookup and the labels stripped from existing rows are the same strings.
+    """
+    labels: set[str] = set()
+    for tag in tags:
+        label_raw = getattr(tag, "label", None)
+        if label_raw is None:
+            continue
+        label = str(label_raw).strip().lower()
+        if label:
+            labels.add(label)
     return labels
 
 

--- a/tests/test_cleanup_media_rules.py
+++ b/tests/test_cleanup_media_rules.py
@@ -5673,3 +5673,167 @@ class CleanupScanIntegrationTests(unittest.IsolatedAsyncioTestCase):
                 await db.execute(select(Series).where(Series.id == series_id))
             ).scalar_one()
             self.assertEqual(unchanged.arr_tags, ["archive-six-stale", "keep"])
+
+    async def test_refresh_arr_tags_regex_rule_unions_labels_across_radarr_configs(
+        self,
+    ) -> None:
+        """Replace-mode correctness depends on label additions accumulating across
+        every successful config before the write loop runs, not on a single config's
+        effective_labels."""
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-regex-union-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            config_one = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-union-one",
+                api_key="x",
+                name="radarr-union-one",
+                enabled=True,
+            )
+            config_two = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-union-two",
+                api_key="x",
+                name="radarr-union-two",
+                enabled=True,
+            )
+            movie = Movie(title="Union Label Movie", tmdb_id=70007, arr_tags=[])
+            db.add_all([rule, config_one, config_two, movie])
+            await db.flush()
+            db.add_all(
+                [
+                    MovieArrRef(
+                        movie_id=movie.id,
+                        service_config_id=config_one.id,
+                        arr_movie_id=6001,
+                        tmdb_id=movie.tmdb_id,
+                    ),
+                    MovieArrRef(
+                        movie_id=movie.id,
+                        service_config_id=config_two.id,
+                        arr_movie_id=6002,
+                        tmdb_id=movie.tmdb_id,
+                    ),
+                ]
+            )
+            await db.commit()
+            config_one_id = config_one.id
+            config_two_id = config_two.id
+            movie_id = movie.id
+
+        # Each config's fake only knows about its own arr_movie_id and only carries
+        # its own tag in its catalog; the union must come from both configs together.
+        client_one = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=6001, tags=[1])],
+            tags=[SimpleNamespace(id=1, label="alpha")],
+        )
+        client_two = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=6002, tags=[2])],
+            tags=[SimpleNamespace(id=2, label="beta")],
+        )
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {  # pyright: ignore[reportAttributeAccessIssue]
+            config_one_id: client_one,
+            config_two_id: client_two,
+        }
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, ["alpha", "beta"])
+
+    async def test_refresh_arr_tags_regex_rule_excludes_movie_reachable_from_failed_radarr_config(
+        self,
+    ) -> None:
+        """A row reachable from any failed config must be excluded from the replace-mode
+        write entirely, even when another config for the same row succeeded."""
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-regex-mixed-health-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            healthy_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-mixed-healthy",
+                api_key="x",
+                name="radarr-mixed-healthy",
+                enabled=True,
+            )
+            failed_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-mixed-failed",
+                api_key="x",
+                name="radarr-mixed-failed",
+                enabled=True,
+            )
+            movie = Movie(
+                title="Mixed Health Movie",
+                tmdb_id=70008,
+                arr_tags=["archive-nine-stale"],
+            )
+            db.add_all([rule, healthy_config, failed_config, movie])
+            await db.flush()
+            db.add_all(
+                [
+                    MovieArrRef(
+                        movie_id=movie.id,
+                        service_config_id=healthy_config.id,
+                        arr_movie_id=6003,
+                        tmdb_id=movie.tmdb_id,
+                    ),
+                    MovieArrRef(
+                        movie_id=movie.id,
+                        service_config_id=failed_config.id,
+                        arr_movie_id=6004,
+                        tmdb_id=movie.tmdb_id,
+                    ),
+                ]
+            )
+            await db.commit()
+            healthy_config_id = healthy_config.id
+            failed_config_id = failed_config.id
+            movie_id = movie.id
+
+        healthy_client = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=6003, tags=[])],
+            tags=[],
+        )
+        failed_client = _RadarrTagRefreshClientFake(fail=True)
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {  # pyright: ignore[reportAttributeAccessIssue]
+            healthy_config_id: healthy_client,
+            failed_config_id: failed_client,
+        }
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            unchanged = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(unchanged.arr_tags, ["archive-nine-stale"])

--- a/tests/test_cleanup_media_rules.py
+++ b/tests/test_cleanup_media_rules.py
@@ -2761,6 +2761,78 @@ if __name__ == "__main__":
     unittest.main()
 
 
+class ArrTagLabelCollectionTests(unittest.TestCase):
+    @staticmethod
+    def _tag_rule(operator: str, value: object) -> ReclaimRule:
+        return _make_single_condition_rule(
+            name=f"tag-rule-{operator}",
+            media_type=MediaType.MOVIE,
+            target_scope="movie_version",
+            field="arr.tags",
+            operator=operator,
+            value=value,
+        )
+
+    def test_exact_operator_values_are_collected_as_labels(self) -> None:
+        rule = self._tag_rule("contains_any", ["keep"])
+        self.assertEqual(cleanup_tasks._collect_arr_tag_labels([rule]), {"keep"})
+        self.assertFalse(cleanup_tasks._has_non_exact_arr_tag_condition([rule]))
+
+    def test_regex_pattern_is_not_collected_as_a_label(self) -> None:
+        rule = self._tag_rule("matches_any_regex", ["archive-.*-stale$"])
+        self.assertEqual(cleanup_tasks._collect_arr_tag_labels([rule]), set())
+        self.assertTrue(cleanup_tasks._has_non_exact_arr_tag_condition([rule]))
+
+    def test_substring_needle_is_not_collected_as_a_label(self) -> None:
+        rule = self._tag_rule("contains_substring", ["stale"])
+        self.assertEqual(cleanup_tasks._collect_arr_tag_labels([rule]), set())
+        self.assertTrue(cleanup_tasks._has_non_exact_arr_tag_condition([rule]))
+
+    def test_negated_non_exact_operators_are_recognised(self) -> None:
+        for operator, value in (
+            ("not_matches_any_regex", ["archive-.*$"]),
+            ("not_contains_substring", ["stale"]),
+        ):
+            with self.subTest(operator=operator):
+                rule = self._tag_rule(operator, value)
+                self.assertEqual(cleanup_tasks._collect_arr_tag_labels([rule]), set())
+                self.assertTrue(
+                    cleanup_tasks._has_non_exact_arr_tag_condition([rule])
+                )
+
+    def test_mixed_rules_collect_exact_labels_and_flag_non_exact(self) -> None:
+        rules = [
+            self._tag_rule("contains_any", ["keep"]),
+            self._tag_rule("matches_any_regex", ["archive-.*-stale$"]),
+        ]
+        self.assertEqual(cleanup_tasks._collect_arr_tag_labels(rules), {"keep"})
+        self.assertTrue(cleanup_tasks._has_non_exact_arr_tag_condition(rules))
+
+    def test_non_tag_field_conditions_are_ignored(self) -> None:
+        rule = _make_single_condition_rule(
+            name="not-a-tag-rule",
+            media_type=MediaType.MOVIE,
+            target_scope="movie_version",
+            field="media.title",
+            operator="contains_substring",
+            value=["stale"],
+        )
+        self.assertEqual(cleanup_tasks._collect_arr_tag_labels([rule]), set())
+        self.assertFalse(cleanup_tasks._has_non_exact_arr_tag_condition([rule]))
+
+    def test_all_catalog_labels_normalises_case_and_skips_blanks(self) -> None:
+        tags = [
+            SimpleNamespace(id=1, label=" Keep "),
+            SimpleNamespace(id=2, label="ARCHIVE-ONE-STALE"),
+            SimpleNamespace(id=3, label=""),
+            SimpleNamespace(id=4, label=None),
+        ]
+        self.assertEqual(
+            cleanup_tasks._all_catalog_labels(tags),
+            {"keep", "archive-one-stale"},
+        )
+
+
 class CleanupScanIntegrationTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         tmp_root = Path("tests/.tmp")

--- a/tests/test_cleanup_media_rules.py
+++ b/tests/test_cleanup_media_rules.py
@@ -5139,3 +5139,243 @@ class CleanupScanIntegrationTests(unittest.IsolatedAsyncioTestCase):
                 settings.leaving_soon_last_success_titles,
                 {Service.PLEX.value: "Old A"},
             )
+
+    async def test_refresh_arr_tags_regex_rule_drops_tag_removed_in_radarr(
+        self,
+    ) -> None:
+        """The reported defect. A regex rule got no per-scan top-up, so a tag removed
+        in Radarr stayed on the row until the next full media sync."""
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-regex-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            radarr_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-a",
+                api_key="x",
+                name="radarr-a",
+                enabled=True,
+            )
+            movie = Movie(
+                title="Formerly Stale Movie",
+                tmdb_id=70001,
+                arr_tags=["archive-one-stale"],
+            )
+            db.add_all([rule, radarr_config, movie])
+            await db.flush()
+            db.add(
+                MovieArrRef(
+                    movie_id=movie.id,
+                    service_config_id=radarr_config.id,
+                    arr_movie_id=2001,
+                    tmdb_id=movie.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = radarr_config.id
+            movie_id = movie.id
+
+        # Radarr still knows the tag, but no longer applies it to this movie.
+        fake_client = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=2001, tags=[])],
+            tags=[SimpleNamespace(id=1, label="archive-one-stale")],
+        )
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, [])
+
+    async def test_refresh_arr_tags_substring_rule_adds_tag_added_in_radarr(
+        self,
+    ) -> None:
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-substring-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="contains_substring",
+                value=["stale"],
+            )
+            radarr_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-b",
+                api_key="x",
+                name="radarr-b",
+                enabled=True,
+            )
+            movie = Movie(title="Newly Stale Movie", tmdb_id=70002, arr_tags=[])
+            db.add_all([rule, radarr_config, movie])
+            await db.flush()
+            db.add(
+                MovieArrRef(
+                    movie_id=movie.id,
+                    service_config_id=radarr_config.id,
+                    arr_movie_id=2002,
+                    tmdb_id=movie.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = radarr_config.id
+            movie_id = movie.id
+
+        fake_client = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=2002, tags=[7])],
+            tags=[SimpleNamespace(id=7, label="archive-two-stale")],
+        )
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, ["archive-two-stale"])
+
+    async def test_refresh_arr_tags_exact_rule_preserves_unreferenced_movie_labels(
+        self,
+    ) -> None:
+        """Exact-match rules keep the narrow behaviour: only referenced labels are
+        refreshed, and labels the rules never mention survive untouched."""
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-exact-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="contains_any",
+                value=["keep"],
+            )
+            radarr_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-c",
+                api_key="x",
+                name="radarr-c",
+                enabled=True,
+            )
+            movie = Movie(
+                title="Partially Tagged Movie",
+                tmdb_id=70003,
+                arr_tags=["keep", "unrelated-label"],
+            )
+            db.add_all([rule, radarr_config, movie])
+            await db.flush()
+            db.add(
+                MovieArrRef(
+                    movie_id=movie.id,
+                    service_config_id=radarr_config.id,
+                    arr_movie_id=2003,
+                    tmdb_id=movie.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = radarr_config.id
+            movie_id = movie.id
+
+        # Radarr reports neither label on the movie. Only "keep" is rule-relevant,
+        # so only "keep" should be stripped.
+        fake_client = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=2003, tags=[])],
+            tags=[
+                SimpleNamespace(id=1, label="keep"),
+                SimpleNamespace(id=2, label="unrelated-label"),
+            ],
+        )
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, ["unrelated-label"])
+
+    async def test_refresh_arr_tags_regex_rule_preserves_failed_radarr_config_rows(
+        self,
+    ) -> None:
+        """Widening the label set must not turn a failed fetch into data loss."""
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-regex-failure-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            radarr_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-down",
+                api_key="x",
+                name="radarr-down",
+                enabled=True,
+            )
+            movie = Movie(
+                title="Unreachable Movie",
+                tmdb_id=70004,
+                arr_tags=["archive-three-stale", "keep"],
+            )
+            db.add_all([rule, radarr_config, movie])
+            await db.flush()
+            db.add(
+                MovieArrRef(
+                    movie_id=movie.id,
+                    service_config_id=radarr_config.id,
+                    arr_movie_id=2004,
+                    tmdb_id=movie.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = radarr_config.id
+            movie_id = movie.id
+
+        fake_client = _RadarrTagRefreshClientFake(fail=True)
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            unchanged = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(unchanged.arr_tags, ["archive-three-stale", "keep"])

--- a/tests/test_cleanup_media_rules.py
+++ b/tests/test_cleanup_media_rules.py
@@ -5503,3 +5503,173 @@ class CleanupScanIntegrationTests(unittest.IsolatedAsyncioTestCase):
                 await db.execute(select(Movie).where(Movie.id == movie_id))
             ).scalar_one()
             self.assertEqual(refreshed.arr_tags, [])
+
+    async def test_refresh_arr_tags_regex_rule_drops_tag_removed_in_sonarr(
+        self,
+    ) -> None:
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="sonarr-regex-rule",
+                media_type=MediaType.SERIES,
+                target_scope="series",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            sonarr_config = ServiceConfig(
+                service_type=Service.SONARR,
+                base_url="http://sonarr-regex",
+                api_key="x",
+                name="sonarr-regex",
+                enabled=True,
+            )
+            series = Series(
+                title="Formerly Stale Series",
+                tmdb_id=90101,
+                arr_tags=["archive-four-stale"],
+            )
+            db.add_all([rule, sonarr_config, series])
+            await db.flush()
+            db.add(
+                SeriesArrRef(
+                    series_id=series.id,
+                    service_config_id=sonarr_config.id,
+                    arr_series_id=3001,
+                    tmdb_id=series.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = sonarr_config.id
+            series_id = series.id
+
+        fake_client = _SonarrTagRefreshClientFake(
+            series=[SimpleNamespace(id=3001, tags=[])],
+            tags=[SimpleNamespace(id=1, label="archive-four-stale")],
+        )
+        previous_sonarr_clients = cleanup_tasks.service_manager._sonarr_clients
+        previous_sonarr = cleanup_tasks.service_manager._sonarr
+        cleanup_tasks.service_manager._sonarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._sonarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._sonarr_clients = previous_sonarr_clients
+            cleanup_tasks.service_manager._sonarr = previous_sonarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Series).where(Series.id == series_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, [])
+
+    async def test_refresh_arr_tags_substring_rule_adds_tag_added_in_sonarr(
+        self,
+    ) -> None:
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="sonarr-substring-rule",
+                media_type=MediaType.SERIES,
+                target_scope="series",
+                field="arr.tags",
+                operator="contains_substring",
+                value=["stale"],
+            )
+            sonarr_config = ServiceConfig(
+                service_type=Service.SONARR,
+                base_url="http://sonarr-substring",
+                api_key="x",
+                name="sonarr-substring",
+                enabled=True,
+            )
+            series = Series(title="Newly Stale Series", tmdb_id=90102, arr_tags=[])
+            db.add_all([rule, sonarr_config, series])
+            await db.flush()
+            db.add(
+                SeriesArrRef(
+                    series_id=series.id,
+                    service_config_id=sonarr_config.id,
+                    arr_series_id=3002,
+                    tmdb_id=series.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = sonarr_config.id
+            series_id = series.id
+
+        fake_client = _SonarrTagRefreshClientFake(
+            series=[SimpleNamespace(id=3002, tags=[9])],
+            tags=[SimpleNamespace(id=9, label="archive-five-stale")],
+        )
+        previous_sonarr_clients = cleanup_tasks.service_manager._sonarr_clients
+        previous_sonarr = cleanup_tasks.service_manager._sonarr
+        cleanup_tasks.service_manager._sonarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._sonarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._sonarr_clients = previous_sonarr_clients
+            cleanup_tasks.service_manager._sonarr = previous_sonarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Series).where(Series.id == series_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, ["archive-five-stale"])
+
+    async def test_refresh_arr_tags_regex_rule_preserves_failed_sonarr_config_rows(
+        self,
+    ) -> None:
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="sonarr-regex-failure-rule",
+                media_type=MediaType.SERIES,
+                target_scope="series",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            sonarr_config = ServiceConfig(
+                service_type=Service.SONARR,
+                base_url="http://sonarr-down",
+                api_key="x",
+                name="sonarr-down",
+                enabled=True,
+            )
+            series = Series(
+                title="Unreachable Series",
+                tmdb_id=90103,
+                arr_tags=["archive-six-stale", "keep"],
+            )
+            db.add_all([rule, sonarr_config, series])
+            await db.flush()
+            db.add(
+                SeriesArrRef(
+                    series_id=series.id,
+                    service_config_id=sonarr_config.id,
+                    arr_series_id=3003,
+                    tmdb_id=series.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = sonarr_config.id
+            series_id = series.id
+
+        fake_client = _SonarrTagRefreshClientFake(fail=True)
+        previous_sonarr_clients = cleanup_tasks.service_manager._sonarr_clients
+        previous_sonarr = cleanup_tasks.service_manager._sonarr
+        cleanup_tasks.service_manager._sonarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._sonarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._sonarr_clients = previous_sonarr_clients
+            cleanup_tasks.service_manager._sonarr = previous_sonarr
+
+        async with self._sessionmaker() as db:
+            unchanged = (
+                await db.execute(select(Series).where(Series.id == series_id))
+            ).scalar_one()
+            self.assertEqual(unchanged.arr_tags, ["archive-six-stale", "keep"])

--- a/tests/test_cleanup_media_rules.py
+++ b/tests/test_cleanup_media_rules.py
@@ -5379,3 +5379,127 @@ class CleanupScanIntegrationTests(unittest.IsolatedAsyncioTestCase):
                 await db.execute(select(Movie).where(Movie.id == movie_id))
             ).scalar_one()
             self.assertEqual(unchanged.arr_tags, ["archive-three-stale", "keep"])
+
+    async def test_refresh_arr_tags_regex_rule_clears_label_whose_tag_was_deleted(
+        self,
+    ) -> None:
+        """A strip set built from the current catalog can't name a deleted tag's
+        label, so full-refresh mode must replace the row instead of patching it."""
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-regex-deleted-tag-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            radarr_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-e",
+                api_key="x",
+                name="radarr-e",
+                enabled=True,
+            )
+            movie = Movie(
+                title="Deleted Tag Movie",
+                tmdb_id=70005,
+                arr_tags=["archive-seven-stale"],
+            )
+            db.add_all([rule, radarr_config, movie])
+            await db.flush()
+            db.add(
+                MovieArrRef(
+                    movie_id=movie.id,
+                    service_config_id=radarr_config.id,
+                    arr_movie_id=2005,
+                    tmdb_id=movie.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = radarr_config.id
+            movie_id = movie.id
+
+        # The tag itself was deleted in Radarr, so the catalog no longer contains
+        # "archive-seven-stale" at all, and the movie carries no tags.
+        fake_client = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=2005, tags=[])],
+            tags=[SimpleNamespace(id=5, label="keep")],
+        )
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, [])
+
+    async def test_refresh_arr_tags_regex_rule_clears_labels_when_catalog_is_empty(
+        self,
+    ) -> None:
+        """An empty catalog fetch must still be treated as a successful refresh,
+        not silently indistinguishable from never having looked."""
+        async with self._sessionmaker() as db:
+            rule = _make_single_condition_rule(
+                name="radarr-regex-empty-catalog-rule",
+                media_type=MediaType.MOVIE,
+                target_scope="movie_version",
+                field="arr.tags",
+                operator="matches_any_regex",
+                value=["archive-.*-stale$"],
+            )
+            radarr_config = ServiceConfig(
+                service_type=Service.RADARR,
+                base_url="http://radarr-f",
+                api_key="x",
+                name="radarr-f",
+                enabled=True,
+            )
+            movie = Movie(
+                title="Empty Catalog Movie",
+                tmdb_id=70006,
+                arr_tags=["archive-eight-stale"],
+            )
+            db.add_all([rule, radarr_config, movie])
+            await db.flush()
+            db.add(
+                MovieArrRef(
+                    movie_id=movie.id,
+                    service_config_id=radarr_config.id,
+                    arr_movie_id=2006,
+                    tmdb_id=movie.tmdb_id,
+                )
+            )
+            await db.commit()
+            config_id = radarr_config.id
+            movie_id = movie.id
+
+        fake_client = _RadarrTagRefreshClientFake(
+            movies=[SimpleNamespace(id=2006, tags=[])],
+            tags=[],
+        )
+        previous_radarr_clients = cleanup_tasks.service_manager._radarr_clients
+        previous_radarr = cleanup_tasks.service_manager._radarr
+        cleanup_tasks.service_manager._radarr_clients = {config_id: fake_client}  # pyright: ignore[reportAttributeAccessIssue]
+        cleanup_tasks.service_manager._radarr = None
+        try:
+            with patch.object(cleanup_tasks, "async_db", self._sessionmaker):
+                await cleanup_tasks._refresh_arr_tags_for_rules([rule])
+        finally:
+            cleanup_tasks.service_manager._radarr_clients = previous_radarr_clients
+            cleanup_tasks.service_manager._radarr = previous_radarr
+
+        async with self._sessionmaker() as db:
+            refreshed = (
+                await db.execute(select(Movie).where(Movie.id == movie_id))
+            ).scalar_one()
+            self.assertEqual(refreshed.arr_tags, [])


### PR DESCRIPTION
## Problem

`arr.tags` supports four operators that match patterns rather than whole tag labels: `matches_any_regex`, `not_matches_any_regex`, `contains_substring` and `not_contains_substring`.

The per-scan tag top-up did not know about them. `_collect_arr_tag_labels` harvested every condition value as a literal tag label whatever the operator, and `_collect_arr_item_ids_by_label` matched those against the arr's tag catalog by exact equality. For a regex condition the harvested "label" is the pattern itself, which names no real tag, so the top-up refreshed nothing for that rule.

Those rules still matched, using tag data written by the last full media sync. They just never received the top-up that exact-match rules get. Since media sync and the cleanup scan run on separate schedules, a tag changed in the arr stayed invisible to them until the next sync rather than the next scan.

Removal is the direction that hurts. Removing a tag is usually an attempt to stop something happening, and for a rule producing deletion candidates that intent could be a full sync cycle late.

## Changes

- Tag label collection is operator-aware, so patterns are no longer mistaken for tag names.
- When any `arr.tags` condition for a media type uses a non-exact operator, the refresh widens to that arr's whole tag catalog. The top-up already fetches every item and the full catalog, so this costs no extra requests.
- Exact-match rules are unchanged: they still refresh only the labels they name, and labels the rules never mention stay on the row.

## Two write modes, and why

The write loop now has two paths, which is worth calling out since it is the least obvious part of the diff.

In exact-match mode it patches: strip the rule-relevant labels, re-add the confirmed ones, leave everything else alone. That is required, because the refresh only knows about labels the rules name.

In full-refresh mode it replaces the row outright. Patching is not sufficient there: a strip set derived from the arr's current catalog cannot name a label whose tag was deleted from that catalog, so a deleted tag would otherwise persist on the row indefinitely. Replacing is safe because the confirmed set is accumulated across every config that succeeded, and any row reachable from a failed config is excluded from the write entirely.

A consequence worth stating plainly: in full-refresh mode a successful fetch returning an empty tag catalog is treated as authoritative and clears the row. That is deliberate and tested. It is the same trust model the media sync already applies, but it is the widest blast radius in this change.

## Why not expand the patterns

The alternative was evaluating each regex or substring against the fetched catalog and adding the labels that match. It was rejected because it would duplicate the evaluator's matching semantics in a second place, and a divergence between the two would produce silently wrong tag data rather than an error. That mismatch is what caused this bug. Refreshing the catalog needs no interpretation of condition values at all.

A useful side effect: full-refresh mode converges on exactly what the full media sync writes, so the two writers of this column now agree instead of diverging between runs.

## Compatibility

Non-destructive-on-failure behaviour is unchanged in both modes. A config whose fetch fails contributes nothing, and rows reachable from a failed config are skipped, including items present in more than one arr.

One cosmetic note: the media sync stores tag labels in their original case while the top-up lowercases them, so under full refresh a row's labels may flip case between a scan and the next sync. Matching is case-insensitive throughout and `arr_tags` has no API or UI consumer, so this has no functional effect.

## Testing

`uv run pytest` passes at 625, ruff clean. The three pre-existing tests for this function are unchanged.

New coverage: tag addition and removal take effect at scan time for both regex and substring rules across Radarr and Sonarr; a label whose tag was deleted from the catalog is cleared; an empty catalog clears the row; exact-match rules still preserve unreferenced labels; labels are unioned across two healthy arr configs; and a row reachable from a failed config is left completely untouched.