### PR TITLE
fix: treat zero-vote TMDB titles as unrated

### DIFF
--- a/backend/alembic/versions/c3f7b1d09a24_clear_unrated_tmdb_ratings.py
+++ b/backend/alembic/versions/c3f7b1d09a24_clear_unrated_tmdb_ratings.py
@@ -23,7 +23,9 @@ def upgrade() -> None:
     # written before the sync stopped storing that value still hold it, where a
     # rating rule reads it as a genuine score of zero. Requiring both a zero
     # rating and a zero vote count means only the sentinel is cleared, so no
-    # real rating can be lost.
+    # real rating can be lost. The sync is stricter, clearing on any zero
+    # vote count alone; this migration deliberately stays narrower so it
+    # cannot destroy one.
     op.execute(
         sa.text(
             """

--- a/backend/alembic/versions/c3f7b1d09a24_clear_unrated_tmdb_ratings.py
+++ b/backend/alembic/versions/c3f7b1d09a24_clear_unrated_tmdb_ratings.py
@@ -1,0 +1,50 @@
+"""Clear stored TMDB ratings for titles with no votes.
+
+Revision ID: c3f7b1d09a24
+Revises: d7f9a2c4e6b8
+Create Date: 2026-08-04 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3f7b1d09a24"
+down_revision: Union[str, None] = "d7f9a2c4e6b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # TMDB returns vote_average as 0 for a title nobody has voted on, and rows
+    # written before the sync stopped storing that value still hold it, where a
+    # rating rule reads it as a genuine score of zero. Requiring both a zero
+    # rating and a zero vote count means only the sentinel is cleared, so no
+    # real rating can be lost.
+    op.execute(
+        sa.text(
+            """
+            UPDATE movies
+            SET vote_average = NULL
+            WHERE vote_count = 0 AND vote_average = 0
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE series
+            SET vote_average = NULL
+            WHERE vote_count = 0 AND vote_average = 0
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Intentionally empty. The cleared values were TMDB's "no rating" marker
+    # rather than data, so there is nothing meaningful to put back.
+    pass

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -1850,8 +1850,11 @@ async def _update_movie_tmdb_metadata(
         movie.overview = movie_metadata.get("overview")
         movie.genres = movie_metadata.get("genres")
         movie.popularity = movie_metadata.get("popularity")
-        movie.vote_average = movie_metadata.get("vote_average")
-        movie.vote_count = movie_metadata.get("vote_count")
+        # TMDB reports vote_average as 0 when nothing has been voted on, so a
+        # stored 0 would read as a genuine bad rating in reclaim rules
+        votes = movie_metadata.get("vote_count")
+        movie.vote_average = movie_metadata.get("vote_average") if votes else None
+        movie.vote_count = votes
         movie.revenue = movie_metadata.get("revenue")
         movie.runtime = movie_metadata.get("runtime")
         movie.status = movie_metadata.get("status")

--- a/backend/tasks/sync.py
+++ b/backend/tasks/sync.py
@@ -3404,8 +3404,11 @@ async def _update_series_tmdb_metadata(
         series.overview = series_metadata.get("overview")
         series.genres = series_metadata.get("genres")
         series.popularity = series_metadata.get("popularity")
-        series.vote_average = series_metadata.get("vote_average")
-        series.vote_count = series_metadata.get("vote_count")
+        # TMDB reports vote_average as 0 when nothing has been voted on, so a
+        # stored 0 would read as a genuine bad rating in reclaim rules
+        votes = series_metadata.get("vote_count")
+        series.vote_average = series_metadata.get("vote_average") if votes else None
+        series.vote_count = votes
         series.status = series_metadata.get("status")
         series.tagline = series_metadata.get("tagline")
         series.season_count = series_metadata.get("number_of_seasons")

--- a/docs/usage/rules.md
+++ b/docs/usage/rules.md
@@ -251,6 +251,11 @@ codes currently found in local TMDB metadata.
 TMDB rating comparisons use the raw `vote_average` value from TMDB on a 0-10
 scale. That is different from percentage-style ratings elsewhere in the app.
 
+TMDB has no rating for a title nobody has voted on. Reclaimerr stores that as an
+empty value rather than as a score of zero, so a comparison such as `<` never
+matches an unrated title. To select those titles, use the `missing` operator on
+the TMDB rating field.
+
 ### External Ratings
 
 External rating fields are available to all scopes. Movie-version rules use the

--- a/docs/usage/rules.md
+++ b/docs/usage/rules.md
@@ -253,8 +253,8 @@ scale. That is different from percentage-style ratings elsewhere in the app.
 
 TMDB has no rating for a title nobody has voted on. Reclaimerr stores that as an
 empty value rather than as a score of zero, so a comparison such as `<` never
-matches an unrated title. To select those titles, use the `missing` operator on
-the TMDB rating field.
+matches an unrated title. Use `does not exist` on the TMDB rating field when
+you specifically want to find those titles.
 
 ### External Ratings
 

--- a/tests/test_sync_tmdb_metadata.py
+++ b/tests/test_sync_tmdb_metadata.py
@@ -97,6 +97,8 @@ class MovieTmdbRatingSyncTests(unittest.IsolatedAsyncioTestCase):
 
         await _update_movie_tmdb_metadata(movie, 1, service)  # type: ignore[arg-type]
 
+        self.assertIsNotNone(movie.last_metadata_refresh_at)
+
         below_five = _rating_rule(
             media_type=MediaType.MOVIE,
             target_scope="movie_version",

--- a/tests/test_sync_tmdb_metadata.py
+++ b/tests/test_sync_tmdb_metadata.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import unittest
+
+from backend.database.models import Movie, MovieVersion, ReclaimRule
+from backend.enums import MediaType, Service
+from backend.tasks.cleanup import _evaluate_movie_rule
+from backend.tasks.sync import _update_movie_tmdb_metadata
+
+
+class _FakeTMDBMovieService:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    async def get_movie_details(self, tmdb_id: int) -> dict:
+        return self._payload
+
+
+def _rating_rule(
+    *,
+    media_type: MediaType,
+    target_scope: str,
+    operator: str,
+    value: object | None = None,
+) -> ReclaimRule:
+    condition: dict[str, object] = {
+        "type": "condition",
+        "field": "tmdb.vote_average",
+        "operator": operator,
+    }
+    if value is not None:
+        condition["value"] = value
+    return ReclaimRule(
+        name="rating-rule",
+        media_type=media_type,
+        enabled=True,
+        target_scope=target_scope,
+        definition={
+            "version": 1,
+            "root": {"type": "group", "op": "and", "children": [condition]},
+        },
+        action={"candidate": True, "media_server_action": "delete"},
+    )
+
+
+def _make_movie() -> Movie:
+    movie = Movie(title="Placeholder Movie", tmdb_id=1, size=10 * 1024**3)
+    movie.versions = [
+        MovieVersion(
+            movie_id=1,
+            service=Service.PLEX,
+            service_item_id="i1",
+            service_media_id="m1",
+            library_id="lib-1",
+            library_name="Library 1",
+        )
+    ]
+    return movie
+
+
+class MovieTmdbRatingSyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_zero_votes_stores_no_rating(self) -> None:
+        movie = _make_movie()
+        service = _FakeTMDBMovieService({"vote_average": 0, "vote_count": 0})
+
+        await _update_movie_tmdb_metadata(movie, 1, service)  # type: ignore[arg-type]
+
+        # the updater swallows exceptions, and an aborted run would leave
+        # vote_average at its model default of None, so assert it completed
+        self.assertIsNotNone(movie.last_metadata_refresh_at)
+        self.assertIsNone(movie.vote_average)
+        self.assertEqual(movie.vote_count, 0)
+
+    async def test_real_votes_store_the_rating_unchanged(self) -> None:
+        movie = _make_movie()
+        service = _FakeTMDBMovieService({"vote_average": 7.5, "vote_count": 1200})
+
+        await _update_movie_tmdb_metadata(movie, 1, service)  # type: ignore[arg-type]
+
+        self.assertIsNotNone(movie.last_metadata_refresh_at)
+        self.assertEqual(movie.vote_average, 7.5)
+        self.assertEqual(movie.vote_count, 1200)
+
+    async def test_missing_vote_count_stores_no_rating(self) -> None:
+        movie = _make_movie()
+        service = _FakeTMDBMovieService({"vote_average": 7.5})
+
+        await _update_movie_tmdb_metadata(movie, 1, service)  # type: ignore[arg-type]
+
+        self.assertIsNotNone(movie.last_metadata_refresh_at)
+        self.assertIsNone(movie.vote_average)
+        self.assertIsNone(movie.vote_count)
+
+    async def test_unrated_movie_is_excluded_from_rating_rules(self) -> None:
+        movie = _make_movie()
+        service = _FakeTMDBMovieService({"vote_average": 0, "vote_count": 0})
+
+        await _update_movie_tmdb_metadata(movie, 1, service)  # type: ignore[arg-type]
+
+        below_five = _rating_rule(
+            media_type=MediaType.MOVIE,
+            target_scope="movie_version",
+            operator="less_than",
+            value=5,
+        )
+        missing = _rating_rule(
+            media_type=MediaType.MOVIE,
+            target_scope="movie_version",
+            operator="not_exists",
+        )
+
+        self.assertFalse(_evaluate_movie_rule(movie, below_five, {}, []))
+        self.assertTrue(_evaluate_movie_rule(movie, missing, {}, []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync_tmdb_metadata.py
+++ b/tests/test_sync_tmdb_metadata.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import unittest
 
-from backend.database.models import Movie, MovieVersion, ReclaimRule
+from backend.database.models import Movie, MovieVersion, ReclaimRule, Series
 from backend.enums import MediaType, Service
 from backend.tasks.cleanup import _evaluate_movie_rule
-from backend.tasks.sync import _update_movie_tmdb_metadata
+from backend.tasks.sync import (
+    _update_movie_tmdb_metadata,
+    _update_series_tmdb_metadata,
+)
 
 
 class _FakeTMDBMovieService:
@@ -13,6 +16,14 @@ class _FakeTMDBMovieService:
         self._payload = payload
 
     async def get_movie_details(self, tmdb_id: int) -> dict:
+        return self._payload
+
+
+class _FakeTMDBSeriesService:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    async def get_tv_details(self, tmdb_id: int) -> dict:
         return self._payload
 
 
@@ -113,6 +124,73 @@ class MovieTmdbRatingSyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(_evaluate_movie_rule(movie, below_five, {}, []))
         self.assertTrue(_evaluate_movie_rule(movie, missing, {}, []))
+
+
+class SeriesTmdbRatingSyncTests(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _make_series() -> Series:
+        return Series(title="Placeholder Series", tmdb_id=2, size=20 * 1024**3)
+
+    async def test_zero_votes_stores_no_rating(self) -> None:
+        series = self._make_series()
+        service = _FakeTMDBSeriesService({"vote_average": 0, "vote_count": 0})
+
+        await _update_series_tmdb_metadata(  # type: ignore[arg-type]
+            series, 2, service
+        )
+
+        self.assertIsNotNone(series.last_metadata_refresh_at)
+        self.assertIsNone(series.vote_average)
+        self.assertEqual(series.vote_count, 0)
+
+    async def test_real_votes_store_the_rating_unchanged(self) -> None:
+        series = self._make_series()
+        service = _FakeTMDBSeriesService({"vote_average": 8.1, "vote_count": 900})
+
+        await _update_series_tmdb_metadata(  # type: ignore[arg-type]
+            series, 2, service
+        )
+
+        self.assertIsNotNone(series.last_metadata_refresh_at)
+        self.assertEqual(series.vote_average, 8.1)
+        self.assertEqual(series.vote_count, 900)
+
+    async def test_missing_vote_count_stores_no_rating(self) -> None:
+        series = self._make_series()
+        service = _FakeTMDBSeriesService({"vote_average": 8.1})
+
+        await _update_series_tmdb_metadata(  # type: ignore[arg-type]
+            series, 2, service
+        )
+
+        self.assertIsNotNone(series.last_metadata_refresh_at)
+        self.assertIsNone(series.vote_average)
+        self.assertIsNone(series.vote_count)
+
+    async def test_unrated_series_is_excluded_from_rating_rules(self) -> None:
+        series = self._make_series()
+        service = _FakeTMDBSeriesService({"vote_average": 0, "vote_count": 0})
+
+        await _update_series_tmdb_metadata(  # type: ignore[arg-type]
+            series, 2, service
+        )
+
+        self.assertIsNotNone(series.last_metadata_refresh_at)
+
+        below_five = _rating_rule(
+            media_type=MediaType.SERIES,
+            target_scope="series",
+            operator="less_than",
+            value=5,
+        )
+        missing = _rating_rule(
+            media_type=MediaType.SERIES,
+            target_scope="series",
+            operator="not_exists",
+        )
+
+        self.assertFalse(_evaluate_movie_rule(series, below_five, {}, []))
+        self.assertTrue(_evaluate_movie_rule(series, missing, {}, []))
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_tmdb_metadata.py
+++ b/tests/test_sync_tmdb_metadata.py
@@ -121,9 +121,15 @@ class MovieTmdbRatingSyncTests(unittest.IsolatedAsyncioTestCase):
             target_scope="movie_version",
             operator="not_exists",
         )
+        present = _rating_rule(
+            media_type=MediaType.MOVIE,
+            target_scope="movie_version",
+            operator="exists",
+        )
 
         self.assertFalse(_evaluate_movie_rule(movie, below_five, {}, []))
         self.assertTrue(_evaluate_movie_rule(movie, missing, {}, []))
+        self.assertFalse(_evaluate_movie_rule(movie, present, {}, []))
 
 
 class SeriesTmdbRatingSyncTests(unittest.IsolatedAsyncioTestCase):
@@ -188,9 +194,15 @@ class SeriesTmdbRatingSyncTests(unittest.IsolatedAsyncioTestCase):
             target_scope="series",
             operator="not_exists",
         )
+        present = _rating_rule(
+            media_type=MediaType.SERIES,
+            target_scope="series",
+            operator="exists",
+        )
 
         self.assertFalse(_evaluate_movie_rule(series, below_five, {}, []))
         self.assertTrue(_evaluate_movie_rule(series, missing, {}, []))
+        self.assertFalse(_evaluate_movie_rule(series, present, {}, []))
 
 
 if __name__ == "__main__":

--- a/tests/test_tmdb_unrated_rating_migration.py
+++ b/tests/test_tmdb_unrated_rating_migration.py
@@ -18,12 +18,15 @@ _CREATE = (
 )
 
 # id 1 is the sentinel, id 2 is a real rating, id 3 has an unknown vote count,
-# id 4 is already clear
+# id 4 is already clear, and id 5 pairs a real rating with zero votes. The sync
+# never writes id 5's shape, but without it the test cannot tell this clause
+# apart from a narrower "vote_count = 0", which would wrongly clear it.
 _ROWS = (
     (1, 0.0, 0),
     (2, 7.5, 1200),
     (3, 0.0, None),
     (4, None, 0),
+    (5, 6.0, 0),
 )
 
 
@@ -56,6 +59,7 @@ def test_migration_clears_only_the_zero_vote_sentinel(monkeypatch, tmp_path) -> 
             assert ratings[2] == 7.5, f"{table}: real rating was modified"
             assert ratings[3] == 0.0, f"{table}: unknown vote count was modified"
             assert ratings[4] is None, f"{table}: already-clear row changed"
+            assert ratings[5] == 6.0, f"{table}: rating with zero votes was cleared"
 
         MIGRATION.downgrade()
 

--- a/tests/test_tmdb_unrated_rating_migration.py
+++ b/tests/test_tmdb_unrated_rating_migration.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+MIGRATION = importlib.import_module(
+    "backend.alembic.versions.c3f7b1d09a24_clear_unrated_tmdb_ratings"
+)
+
+_CREATE = (
+    "CREATE TABLE {table} ("
+    "id INTEGER PRIMARY KEY, "
+    "vote_average FLOAT, "
+    "vote_count INTEGER)"
+)
+
+# id 1 is the sentinel, id 2 is a real rating, id 3 has an unknown vote count,
+# id 4 is already clear
+_ROWS = (
+    (1, 0.0, 0),
+    (2, 7.5, 1200),
+    (3, 0.0, None),
+    (4, None, 0),
+)
+
+
+def test_migration_clears_only_the_zero_vote_sentinel(monkeypatch, tmp_path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'ratings.db'}")
+    with engine.begin() as connection:
+        for table in ("movies", "series"):
+            connection.execute(text(_CREATE.format(table=table)))
+            for row_id, rating, votes in _ROWS:
+                connection.execute(
+                    text(
+                        f"INSERT INTO {table} (id, vote_average, vote_count) "
+                        "VALUES (:id, :rating, :votes)"
+                    ),
+                    {"id": row_id, "rating": rating, "votes": votes},
+                )
+
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(MIGRATION, "op", operations)
+
+        MIGRATION.upgrade()
+
+        for table in ("movies", "series"):
+            ratings = dict(
+                connection.execute(
+                    text(f"SELECT id, vote_average FROM {table}")
+                ).all()
+            )
+            assert ratings[1] is None, f"{table}: sentinel row was not cleared"
+            assert ratings[2] == 7.5, f"{table}: real rating was modified"
+            assert ratings[3] == 0.0, f"{table}: unknown vote count was modified"
+            assert ratings[4] is None, f"{table}: already-clear row changed"
+
+        MIGRATION.downgrade()
+
+        for table in ("movies", "series"):
+            assert (
+                connection.execute(
+                    text(f"SELECT vote_average FROM {table} WHERE id = 1")
+                ).scalar_one()
+                is None
+            ), f"{table}: downgrade should not restore the sentinel"
+
+    engine.dispose()


### PR DESCRIPTION
TMDB returns `vote_average: 0` for a title nobody has voted on, rather than null, and the media sync stored that verbatim. A rule such as "TMDB rating `<` 5" therefore matched every unrated title in the library and nominated it for deletion. It was the only rating field that did not fail closed on missing data.

Checked against a live library of roughly 2,900 movies: 9 rows held `vote_average = 0`, and all 9 had `vote_count = 0`. No row had a real rating with zero votes, or a zero rating with votes.

## The fix

Both TMDB metadata write sites now store no rating when TMDB reports no votes:

```python
votes = movie_metadata.get("vote_count")
movie.vote_average = movie_metadata.get("vote_average") if votes else None
movie.vote_count = votes
```

A missing `vote_count` is treated the same as zero. A rating with no vote count behind it cannot be corroborated, and suppressing it produces fewer deletion candidates, so the failure direction is the safe one.

The rule engine is unchanged. Its comparison path already discards a null before comparing, and `not_exists` already matches one. Season and episode scopes inherit the fix because they read the parent series values.

`None` was chosen over `RULE_VALUE_UNAVAILABLE` deliberately. That sentinel drives the three-valued logic in `evaluate_advanced_rule_state`, which the cleanup task reads as "external data has not been fetched yet", including one site that preserves an existing protection rather than re-evaluating it. Zero votes is not pending data. `_matches_operator` also short-circuits on the sentinel before reaching the `not_exists` branch, so using it would have removed the one operator that should work here.

## Existing rows

A migration clears the sentinel from rows written before this change. It matches only rows holding both a zero rating and a zero vote count, so it cannot discard a real rating. The sync is stricter than that, and the migration deliberately stays narrower. The downgrade is intentionally a no-op, because the cleared value was a marker rather than data, and restoring it would reintroduce the bug on the way down.

## Behaviour change

Two operators change for unrated titles:

| Condition on TMDB rating | Before | After |
| --- | --- | --- |
| `<` a threshold | matches, becomes a candidate | no match |
| `exists` | matches | no match |
| `does not exist` | no match | matches |

An existing rule using either of the first two will visibly shrink its candidate list. `does not exist` is now how to select unrated titles, and the rules documentation says so.

## Testing

`tests/test_sync_tmdb_metadata.py` covers both write sites: zero votes stores no rating, real votes are stored unchanged, and a missing vote count stores no rating. End-to-end tests confirm an unrated title no longer matches a `<` or `exists` rule, and does match `does not exist`. Every test also asserts the updater ran to completion, because it swallows exceptions and would otherwise leave the field at its default null and pass without exercising anything.

`tests/test_tmdb_unrated_rating_migration.py` runs the migration against a scratch database across five row shapes, including a real rating paired with zero votes that must survive untouched. Narrowing the clause to `vote_count = 0` alone fails that test.

Full suite passes, with no changes to the rule engine.
