### PR TITLE
chore: sync uv.lock with the project version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1547,7 +1547,7 @@ wheels = [
 
 [[package]]
 name = "reclaimerr"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
`pyproject.toml` has been at `0.3.4` while `uv.lock` still recorded the `reclaimerr` package as `0.3.3`. Every `uv run` or `uv sync` re-resolved that entry and left `uv.lock` modified in the working tree, which has been showing up as stray noise across the last few branches.

One line, and `uv lock --check` exits 0 afterwards.

It comes back whenever a version bump lands without a re-lock, so running `uv lock` in the commit that bumps the version would stop it recurring.