### PR TITLE
Harden trusted proxy authentication before merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Opt-in trusted proxy authentication with configurable user headers, strict proxy allowlisting, and existing-user mapping for Authelia-style forward auth
+- Optional recovery mode and identity provider sign-out URL for trusted proxy authentication
 
 ### Fixed
 
 - Disk-free rules now use the mounted media volume in Docker and apply scoped path mappings before falling back to Radarr or Sonarr disk data
+- Trusted proxy allowlists now reject all-address ranges such as `0.0.0.0/0`, not just `*`
+- Trusted proxy authentication now fails closed when the proxy header wrapper has not recorded the socket peer
 
 ## [0.3.4] - 2026-07-29
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -44,9 +44,10 @@ from backend.core.service_bootstrap import load_enabled_services
 from backend.core.service_manager import service_manager
 from backend.core.settings import settings
 from backend.core.worker import start_worker_pool
-from backend.database import close_db, init_db
+from backend.database import async_db, close_db, init_db
 from backend.jobs.queue import reset_stale_jobs
 from backend.scheduler import shutdown_scheduler, start_scheduler
+from backend.services.admin_notices import sync_forward_auth_fallback_notice
 from backend.services.lifecycle_webhooks import recover_pending_webhook_deliveries
 from backend.utils.create_admin import create_initial_admin
 
@@ -96,12 +97,30 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 f"{settings.forward_auth_user_header} from "
                 f"{', '.join(settings.forward_auth_trusted_proxies_list)}"
             )
+            if settings.forward_auth_allow_local_fallback:
+                LOG.warning(
+                    "FORWARD_AUTH_ALLOW_LOCAL_FALLBACK is enabled. An unrecognised "
+                    "proxy identity will fall back to local password login. Remove "
+                    "this variable once the matching user exists."
+                )
 
         # init db
         await init_db()
 
         # check if admin account needs created
         await create_initial_admin()
+
+        # Recovery mode is only meaningful while forward auth is on; with it off
+        # the fallback is inert and a notice would be noise.
+        async with async_db() as session:
+            await sync_forward_auth_fallback_notice(
+                session,
+                fallback_active=(
+                    settings.forward_auth_enabled
+                    and settings.forward_auth_allow_local_fallback
+                ),
+            )
+            await session.commit()
 
         # load service configs from database and initialize clients
         await load_enabled_services()

--- a/backend/api/routes/account.py
+++ b/backend/api/routes/account.py
@@ -42,6 +42,7 @@ from backend.models.auth import (
     ChangePasswordRequest,
     ChangeProfileInfoRequest,
     CreateUserRequest,
+    CurrentUserInfo,
     MediaIdentityItem,
     MediaIdentityLinkRequest,
     MediaIdentityListResponse,
@@ -119,12 +120,24 @@ def _serialize_media_identity(
     )
 
 
-@router.get("/me", response_model=UserInfo)
+@router.get("/me", response_model=CurrentUserInfo)
 async def get_me(
+    request: Request,
     current_user: Annotated[User, Depends(get_current_user)],
-) -> UserInfo:
-    """Get current user info."""
-    return UserInfo.from_user(current_user)
+) -> CurrentUserInfo:
+    """Get current user info plus how this session was authenticated."""
+    auth_source = (
+        "forward_auth"
+        if getattr(request.state, "auth_method", None) == "forward_auth"
+        else "local"
+    )
+    logout_url: str | None = None
+    if auth_source == "forward_auth":
+        logout_url = settings.forward_auth_logout_url or None
+
+    return CurrentUserInfo.from_current_user(
+        current_user, auth_source=auth_source, logout_url=logout_url
+    )
 
 
 @router.post("/me")

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
-from ipaddress import ip_address, ip_network
+from functools import lru_cache
+from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
 from typing import Annotated, Any
 from uuid import uuid4
 
@@ -33,6 +34,39 @@ SESSION_LAST_SEEN_TOUCH_INTERVAL = timedelta(minutes=5)
 SESSION_TOUCH_BUSY_TIMEOUT_MS = 250
 DEFAULT_SQLITE_BUSY_TIMEOUT_MS = 30000
 ORIGINAL_CLIENT_HOST_STATE_KEY = "reclaimerr_original_client_host"
+
+FORWARD_AUTH_WARNED_PEERS_MAX = 256
+_forward_auth_warned_peers: set[str] = set()
+
+
+@lru_cache(maxsize=8)
+def _parse_trusted_networks(raw: str) -> tuple[IPv4Network | IPv6Network, ...]:
+    """Parse the forward-auth allowlist once per distinct configured value.
+
+    Keyed on the raw string rather than cached on Settings, so tests that
+    monkeypatch settings.forward_auth_trusted_proxies get a fresh entry instead
+    of a stale one.
+    """
+    return tuple(
+        ip_network(entry.strip(), strict=False)
+        for entry in raw.split(",")
+        if entry.strip()
+    )
+
+
+def _log_untrusted_forward_auth_peer(peer: str) -> None:
+    """Warn once per peer, then drop to debug, so probing cannot flood the log."""
+    message = (
+        f"Ignored {settings.forward_auth_user_header} authentication header "
+        f"from untrusted peer {peer}"
+    )
+    if peer in _forward_auth_warned_peers:
+        LOG.debug(message)
+        return
+    if len(_forward_auth_warned_peers) >= FORWARD_AUTH_WARNED_PEERS_MAX:
+        _forward_auth_warned_peers.clear()
+    _forward_auth_warned_peers.add(peer)
+    LOG.warning(message)
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -174,8 +208,8 @@ def _is_forward_auth_proxy_trusted(request: Request) -> bool:
         return False
 
     return any(
-        client_ip in ip_network(network, strict=False)
-        for network in settings.forward_auth_trusted_proxies_list
+        client_ip in network
+        for network in _parse_trusted_networks(settings.forward_auth_trusted_proxies)
     )
 
 
@@ -192,10 +226,8 @@ async def _get_forward_auth_user(
         return None
 
     if not _is_forward_auth_proxy_trusted(request):
-        LOG.warning(
-            f"Ignored {settings.forward_auth_user_header} authentication header "
-            "from untrusted peer "
-            f"{_get_original_client_host(request) or 'unknown'}"
+        _log_untrusted_forward_auth_peer(
+            _get_original_client_host(request) or "unknown"
         )
         return None
 

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -153,8 +153,13 @@ def _get_original_client_host(request: Request) -> str | None:
         if isinstance(original_host, str) and original_host:
             return original_host
 
-    if request.client and request.client.host:
-        return request.client.host
+    # No snapshot means the outer proxy-header wrapper did not run, so
+    # request.client may already have been rewritten from X-Forwarded-For by
+    # some other layer. Treat the peer as unknown rather than trusting it.
+    LOG.debug(
+        "Proxy header wrapper did not record the socket peer; "
+        "treating this request as untrusted for forward auth"
+    )
     return None
 
 

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -37,6 +37,7 @@ ORIGINAL_CLIENT_HOST_STATE_KEY = "reclaimerr_original_client_host"
 
 FORWARD_AUTH_WARNED_PEERS_MAX = 256
 _forward_auth_warned_peers: set[str] = set()
+_forward_auth_warned_missing_wrapper = False
 
 
 @lru_cache(maxsize=8)
@@ -47,10 +48,18 @@ def _parse_trusted_networks(raw: str) -> tuple[IPv4Network | IPv6Network, ...]:
     monkeypatch settings.forward_auth_trusted_proxies get a fresh entry instead
     of a stale one.
     """
+    # Settings validation already rejects 0.0.0.0/0 and ::/0, but Settings does
+    # not set validate_assignment, so a direct attribute assignment bypasses
+    # that validator. Re-check here as defence in depth so an all-address
+    # range can never confer trust, however the value arrived.
     return tuple(
-        ip_network(entry.strip(), strict=False)
-        for entry in raw.split(",")
-        if entry.strip()
+        network
+        for network in (
+            ip_network(entry.strip(), strict=False)
+            for entry in raw.split(",")
+            if entry.strip()
+        )
+        if network.prefixlen != 0
     )
 
 
@@ -66,6 +75,22 @@ def _log_untrusted_forward_auth_peer(peer: str) -> None:
     if len(_forward_auth_warned_peers) >= FORWARD_AUTH_WARNED_PEERS_MAX:
         _forward_auth_warned_peers.clear()
     _forward_auth_warned_peers.add(peer)
+    LOG.warning(message)
+
+
+def _log_missing_proxy_wrapper() -> None:
+    """Warn once per process that the proxy header wrapper did not run."""
+    global _forward_auth_warned_missing_wrapper
+    message = (
+        "Forward auth is enabled but the proxy header wrapper did not record "
+        "the socket peer, so this request cannot be trusted and forward auth "
+        "is inactive. Serve backend.api.main:app rather than the bare FastAPI "
+        "app, and disable any other proxy-header middleware in front of it."
+    )
+    if _forward_auth_warned_missing_wrapper:
+        LOG.debug(message)
+        return
+    _forward_auth_warned_missing_wrapper = True
     LOG.warning(message)
 
 
@@ -190,10 +215,6 @@ def _get_original_client_host(request: Request) -> str | None:
     # No snapshot means the outer proxy-header wrapper did not run, so
     # request.client may already have been rewritten from X-Forwarded-For by
     # some other layer. Treat the peer as unknown rather than trusting it.
-    LOG.debug(
-        "Proxy header wrapper did not record the socket peer; "
-        "treating this request as untrusted for forward auth"
-    )
     return None
 
 
@@ -225,10 +246,13 @@ async def _get_forward_auth_user(
     if not asserted_usernames:
         return None
 
+    client_host = _get_original_client_host(request)
+    if client_host is None:
+        _log_missing_proxy_wrapper()
+        return None
+
     if not _is_forward_auth_proxy_trusted(request):
-        _log_untrusted_forward_auth_peer(
-            _get_original_client_host(request) or "unknown"
-        )
+        _log_untrusted_forward_auth_peer(client_host)
         return None
 
     if len(asserted_usernames) != 1:

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -216,6 +216,11 @@ async def _get_forward_auth_user(
     user = result.scalar_one_or_none()
     if user is None:
         LOG.warning(f"Trusted proxy user {username!r} is not configured in Reclaimerr")
+        if settings.forward_auth_allow_local_fallback:
+            # Recovery mode: let the request try local cookie auth so an admin can
+            # sign in and create the missing user. Still needs a valid JWT and a
+            # live session row, so this is not a bypass.
+            return None
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Trusted proxy user is not configured",

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -101,6 +101,14 @@ class Settings(BaseSettings):
             "0.0.0.0/0 are not accepted."
         ),
     )
+    forward_auth_allow_local_fallback: bool = Field(
+        default=False,
+        description=(
+            "Recovery switch. When the trusted proxy asserts a username that does "
+            "not exist in Reclaimerr, fall back to local cookie login instead of "
+            "denying the request. Remove once the matching user exists."
+        ),
+    )
 
     # JWT authentication
     jwt_secret: str = Field(

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -97,7 +97,8 @@ class Settings(BaseSettings):
         default="",
         description=(
             "Comma-separated direct proxy IPs or CIDRs allowed to supply the "
-            "forward-auth user header. Wildcards are not accepted."
+            "forward-auth user header. Wildcards and all-address ranges such as "
+            "0.0.0.0/0 are not accepted."
         ),
     )
 
@@ -232,16 +233,24 @@ class Settings(BaseSettings):
             if entry == "*":
                 raise PydanticCustomError(
                     "unsafe_forward_auth_proxy_wildcard",
-                    "FORWARD_AUTH_TRUSTED_PROXIES does not accept '*'",
+                    "FORWARD_AUTH_TRUSTED_PROXIES does not accept '*' or "
+                    "all-address ranges such as 0.0.0.0/0",
                 )
             try:
-                ipaddress.ip_network(entry, strict=False)
+                network = ipaddress.ip_network(entry, strict=False)
             except ValueError as exc:
                 raise PydanticCustomError(
                     "invalid_forward_auth_proxy",
                     "Invalid proxy IP or CIDR in FORWARD_AUTH_TRUSTED_PROXIES: {entry}",
                     {"entry": entry},
                 ) from exc
+            if network.prefixlen == 0:
+                raise PydanticCustomError(
+                    "unsafe_forward_auth_proxy_wildcard",
+                    "FORWARD_AUTH_TRUSTED_PROXIES does not accept '*' or "
+                    "all-address ranges such as {entry}",
+                    {"entry": entry},
+                )
         return ",".join(entries)
 
     @field_validator("jwt_secret", mode="before")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -6,6 +6,7 @@ import os
 import re
 import secrets
 from pathlib import Path
+from urllib.parse import urlparse
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
@@ -107,6 +108,13 @@ class Settings(BaseSettings):
             "Recovery switch. When the trusted proxy asserts a username that does "
             "not exist in Reclaimerr, fall back to local cookie login instead of "
             "denying the request. Remove once the matching user exists."
+        ),
+    )
+    forward_auth_logout_url: str = Field(
+        default="",
+        description=(
+            "Absolute URL of the identity provider sign-out endpoint. When set, "
+            "the UI shows a logout control that redirects here instead of hiding it."
         ),
     )
 
@@ -260,6 +268,21 @@ class Settings(BaseSettings):
                     {"entry": entry},
                 )
         return ",".join(entries)
+
+    @field_validator("forward_auth_logout_url", mode="before")
+    @classmethod
+    def validate_forward_auth_logout_url(cls, v: object) -> str:
+        """Require an absolute http(s) URL so the UI cannot be sent to a script URI."""
+        value = "" if v is None else str(v).strip()
+        if not value:
+            return ""
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise PydanticCustomError(
+                "invalid_forward_auth_logout_url",
+                "FORWARD_AUTH_LOGOUT_URL must be an absolute http or https URL",
+            )
+        return value
 
     @field_validator("jwt_secret", mode="before")
     @classmethod

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -209,6 +209,33 @@ class UserInfo(BaseModel, UsernameMixin, DisplayNameMixin):
         )
 
 
+class CurrentUserInfo(UserInfo):
+    """UserInfo plus how the current request was authenticated.
+
+    Session-scoped, so it is used only by GET /api/account/me. UserInfo itself
+    stays unchanged for login and the admin user list, where these fields would
+    always be null.
+    """
+
+    auth_source: Literal["forward_auth", "local"] = "local"
+    logout_url: str | None = None
+
+    @classmethod
+    def from_current_user(
+        cls,
+        user: Any,
+        *,
+        auth_source: Literal["forward_auth", "local"],
+        logout_url: str | None,
+    ) -> "CurrentUserInfo":
+        """Build from a DB user plus the current request's auth context."""
+        return cls(
+            **UserInfo.from_user(user).model_dump(),
+            auth_source=auth_source,
+            logout_url=logout_url,
+        )
+
+
 class AuthResponse(BaseModel):
     user: UserInfo
 

--- a/backend/services/admin_notices.py
+++ b/backend/services/admin_notices.py
@@ -14,6 +14,7 @@ NOTICE_KEY_SEERR_RULE_SKIP = "seerr_rules_skipped"
 NOTICE_KEY_SONARR_RULE_DATA = "sonarr_rule_data_unavailable"
 NOTICE_KEY_PLAYBACK_RULE_DATA = "playback_rule_data_unavailable"
 NOTICE_KEY_STALE_LIBRARY_IDS = "stale_library_ids"
+NOTICE_KEY_FORWARD_AUTH_FALLBACK = "forward_auth_local_fallback_enabled"
 
 
 def _normalize_context(context: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -261,6 +262,36 @@ async def sync_update_available_notice(
             "latest_version": latest_version,
             "latest_release_url": latest_release_url,
         },
+    )
+
+
+async def sync_forward_auth_fallback_notice(
+    db: AsyncSession,
+    *,
+    fallback_active: bool,
+) -> None:
+    """Creates or resolves the notice for forward-auth recovery mode."""
+    if not fallback_active:
+        await resolve_singleton_notice(db, dedupe_key=NOTICE_KEY_FORWARD_AUTH_FALLBACK)
+        return
+
+    await upsert_singleton_notice(
+        db,
+        dedupe_key=NOTICE_KEY_FORWARD_AUTH_FALLBACK,
+        kind="forward_auth_local_fallback",
+        severity="warning",
+        title="Trusted proxy recovery mode is enabled",
+        message=(
+            "FORWARD_AUTH_ALLOW_LOCAL_FALLBACK is enabled, so a proxy identity "
+            "that does not match a Reclaimerr user falls back to local password "
+            "login instead of being denied. Remove the variable once the "
+            "matching user exists."
+        ),
+        action_label="View trusted proxy documentation",
+        action_href=(
+            "https://jessielw.github.io/Reclaimerr/getting-started/configuration/"
+            "#trusted-proxy-authentication"
+        ),
     )
 
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -31,6 +31,8 @@ PROXY_TRUSTED_HOSTS=127.0.0.1,::1
 # FORWARD_AUTH_ENABLED=true
 # FORWARD_AUTH_USER_HEADER=Remote-User
 # FORWARD_AUTH_TRUSTED_PROXIES=172.18.0.4
+# FORWARD_AUTH_ALLOW_LOCAL_FALLBACK=true
+# FORWARD_AUTH_LOGOUT_URL=https://auth.example.com/logout
 # Advanced; default 2, supported range 1-8
 RECLAIMERR_COMMAND_WORKERS=2
 ```
@@ -48,9 +50,13 @@ headers are preserved and `PROXY_TRUSTED_HOSTS` points at the proxy IP or CIDR.
 Set `Application URL` in General Settings if you want Plex and OIDC callbacks
 to use a fixed public base URL.
 
-For Authelia or another forward-auth provider, enable the three
-`FORWARD_AUTH_*` settings shown above and ensure the asserted username already
-exists in Reclaimerr. `FORWARD_AUTH_TRUSTED_PROXIES` is deliberately separate
-from `PROXY_TRUSTED_HOSTS` and does not permit `*`.
+For Authelia or another forward-auth provider, enable the core
+`FORWARD_AUTH_*` settings shown above and make sure the asserted username
+already exists in Reclaimerr. `FORWARD_AUTH_TRUSTED_PROXIES` is deliberately separate
+from `PROXY_TRUSTED_HOSTS` and rejects both `*` and all-address ranges such as
+`0.0.0.0/0`. The two optional settings add a local-login recovery path and an
+identity provider sign-out link for the UI; see
+[Trusted Proxy Authentication](../getting-started/configuration.md#trusted-proxy-authentication)
+for details.
 
 See the [production guide](production.md) for the hardening checklist.

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -44,9 +44,12 @@ For production deployments, use this guide.
   `Application URL` in General Settings for the shared public base URL, and
   keep `redirect_uri_override` for OIDC-only cases.
 - Keep the backend port private if the proxy is the only ingress point.
-- When using trusted-header authentication, never use a wildcard proxy range;
-  ensure the proxy overwrites incoming identity headers and maps only existing
-  Reclaimerr users.
+- When using trusted-header authentication, never use a wildcard or
+  all-address proxy range such as `0.0.0.0/0`; Reclaimerr rejects both. The
+  proxy must strip the client-supplied identity header before the auth step
+  runs, not just overwrite it. See
+  [Trusted Proxy Authentication](../getting-started/configuration.md#trusted-proxy-authentication)
+  for the reasoning and a verified Caddy example.
 - Reclaimerr has no CSRF tokens and relies on `SameSite=lax` session cookies. Under
   trusted-header authentication its own cookie is not what authenticates the request, so
   cross-site protection depends on your proxy's session cookie configuration. Keep that

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -22,6 +22,8 @@ For production deployments, use this guide.
 | `FORWARD_AUTH_ENABLED`       | Enables opt-in trusted-header authentication                                      |
 | `FORWARD_AUTH_USER_HEADER`   | Selects the proxy-provided username header                                        |
 | `FORWARD_AUTH_TRUSTED_PROXIES` | Restricts identity headers to direct proxy IPs/CIDRs                             |
+| `FORWARD_AUTH_ALLOW_LOCAL_FALLBACK` | Recovery switch for an unrecognised proxy identity; remove after use |
+| `FORWARD_AUTH_LOGOUT_URL`    | Identity provider sign-out endpoint used by the UI logout control                 |
 | `CORS_ORIGINS`               | Restricts the UI origins that can talk to the API                                 |
 | `COOKIE_SECURE`              | Marks auth cookies secure when served over HTTPS                                  |
 | `RECLAIMERR_COMMAND_WORKERS` | Advanced internal command executor count (default `2`, range `1`-`8`)             |
@@ -45,6 +47,10 @@ For production deployments, use this guide.
 - When using trusted-header authentication, never use a wildcard proxy range;
   ensure the proxy overwrites incoming identity headers and maps only existing
   Reclaimerr users.
+- Reclaimerr has no CSRF tokens and relies on `SameSite=lax` session cookies. Under
+  trusted-header authentication its own cookie is not what authenticates the request, so
+  cross-site protection depends on your proxy's session cookie configuration. Keep that
+  cookie's `SameSite` at `lax` or stricter.
 
 ## Operational Notes
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -24,6 +24,8 @@ set of environment variables for the runtime container or desktop process.
 | `FORWARD_AUTH_ENABLED`       | Trust an authenticated username supplied by an approved reverse proxy      |
 | `FORWARD_AUTH_USER_HEADER`   | Forward-auth username header (default: `Remote-User`)                      |
 | `FORWARD_AUTH_TRUSTED_PROXIES` | Direct proxy IPs/CIDRs permitted to supply the identity header            |
+| `FORWARD_AUTH_ALLOW_LOCAL_FALLBACK` | Recovery switch: allow local login when the asserted username is unrecognized (default: off) |
+| `FORWARD_AUTH_LOGOUT_URL`    | Identity provider sign-out endpoint used by the UI logout control          |
 | `JWT_SECRET`                 | Session signing secret                                                     |
 | `ENCRYPTION_KEY`             | Secrets encryption key                                                     |
 | `ADMIN_PASSWORD`             | Initial admin password or admin password reset on startup                  |
@@ -35,26 +37,75 @@ callback generation behind a reverse proxy.
 
 ## Trusted Proxy Authentication
 
-Reclaimerr can use an identity asserted by Authelia or another forward-auth
-proxy. This is disabled by default and maps only to an existing, active
-Reclaimerr user; it never creates accounts or grants roles automatically.
+Reclaimerr can trust a username asserted by Authelia or another forward-auth
+reverse proxy instead of requiring a local sign-in. This is disabled by
+default, and it never creates accounts or grants roles: it only maps an
+asserted username onto an existing, active Reclaimerr user. Local sign-in
+keeps working for requests where the trusted proxy does not assert an
+identity.
 
 ```env
 FORWARD_AUTH_ENABLED=true
 FORWARD_AUTH_USER_HEADER=Remote-User
 FORWARD_AUTH_TRUSTED_PROXIES=172.18.0.4
+# Optional: identity provider sign-out endpoint
+FORWARD_AUTH_LOGOUT_URL=https://auth.example.com/logout
 ```
 
-The supplied username must exactly match a Reclaimerr username. Configure the
-allowlist with the direct TCP address or CIDR of the reverse proxy container or
-host. Wildcards are rejected. Keep Reclaimerr's backend port inaccessible to
-untrusted clients, and configure the proxy to overwrite rather than preserve
-any incoming identity header.
+!!! warning "Configure the proxy to strip the header, not just overwrite it"
 
-Local cookie login remains available when the trusted proxy does not assert an
-identity. When it does assert one, that identity is authoritative and an
-unknown or disabled user is denied instead of falling back to a local session.
-Signing out of the upstream identity provider remains the proxy's responsibility.
+    Reclaimerr rejects any request that carries two values of the identity
+    header, so a proxy that *appends* its own header to a client-supplied one
+    already fails safely: the duplicate is refused. The dangerous case is a
+    proxy that passes the client's header straight through unchanged on
+    requests where the auth step did not set one. Strip the header before the
+    auth step runs, not after it, so there is nothing left for the auth step
+    to accidentally pass through.
+
+    Caddy example using `forward_auth` with Authelia:
+
+    ```caddy
+    reclaimerr.example.com {
+        route {
+            # Strip any client-supplied identity header before authentication runs,
+            # so it can never survive into the upstream request.
+            request_header -Remote-User
+
+            forward_auth authelia:9091 {
+                uri /api/authz/forward-auth
+                copy_headers Remote-User
+            }
+        }
+
+        reverse_proxy reclaimerr:8000
+    }
+    ```
+
+    The `route` block matters here: Caddy's built-in directive order runs
+    `forward_auth` before `request_header` by default, regardless of the
+    order they are written. Without `route`, the header would not actually be
+    stripped before the auth step runs.
+
+Create the Reclaimerr user first, then enable the feature. The asserted
+username must match an existing Reclaimerr username exactly, including case.
+A mismatch produces a 401 on every request, plus a log line naming the
+asserted username.
+
+If you get locked out, for example the feature was enabled before the
+matching user existed, set `FORWARD_AUTH_ALLOW_LOCAL_FALLBACK=true` and
+restart. Sign in locally, create the matching user, then remove the variable
+and restart again. While the variable is set, an admin notice stays visible
+in the sidebar as a reminder to turn it back off.
+
+`FORWARD_AUTH_TRUSTED_PROXIES` takes a comma-separated list of direct proxy
+IPs and CIDRs: the address of the reverse proxy container or host itself, not
+the client behind it. It rejects both `*` and all-address ranges such as
+`0.0.0.0/0` or `::/0`.
+
+The sidebar logout control only appears when `FORWARD_AUTH_LOGOUT_URL` is set,
+since signing out of the identity provider is the proxy's job, not
+Reclaimerr's. When it is unset, the logout control is replaced by a
+non-interactive "Managed by SSO" label.
 
 ## Multi-Server Setup
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -86,6 +86,9 @@ FORWARD_AUTH_LOGOUT_URL=https://auth.example.com/logout
     order they are written. Without `route`, the header would not actually be
     stripped before the auth step runs.
 
+    `Remote-User` here is the default. If `FORWARD_AUTH_USER_HEADER` is set to
+    something else, strip that header name instead of `Remote-User`.
+
 Create the Reclaimerr user first, then enable the feature. The asserted
 username must match an existing Reclaimerr username exactly, including case.
 A mismatch produces a 401 on every request, plus a log line naming the
@@ -102,10 +105,13 @@ IPs and CIDRs: the address of the reverse proxy container or host itself, not
 the client behind it. It rejects both `*` and all-address ranges such as
 `0.0.0.0/0` or `::/0`.
 
-The sidebar logout control only appears when `FORWARD_AUTH_LOGOUT_URL` is set,
-since signing out of the identity provider is the proxy's job, not
-Reclaimerr's. When it is unset, the logout control is replaced by a
-non-interactive "Managed by SSO" label.
+For a trusted-proxy session, the sidebar logout control only appears when
+`FORWARD_AUTH_LOGOUT_URL` is set, since signing out of the identity provider
+is the proxy's job, not Reclaimerr's. When it is unset, the logout control is
+replaced by a "Managed by SSO" label. This does not apply to a local session
+started through `FORWARD_AUTH_ALLOW_LOCAL_FALLBACK` recovery mode: that
+session gets the normal logout button regardless of
+`FORWARD_AUTH_LOGOUT_URL`.
 
 ## Multi-Server Setup
 

--- a/frontend/src/lib/components/sidebar.svelte
+++ b/frontend/src/lib/components/sidebar.svelte
@@ -14,6 +14,7 @@
   import Settings from "@lucide/svelte/icons/settings";
   import DoorOpen from "@lucide/svelte/icons/door-open";
   import DoorClosed from "@lucide/svelte/icons/door-closed";
+  import ShieldCheck from "@lucide/svelte/icons/shield-check";
   import HardDrive from "@lucide/svelte/icons/hard-drive";
   import Ticket from "@lucide/svelte/icons/ticket";
   import Shield from "@lucide/svelte/icons/shield";
@@ -157,9 +158,21 @@
     return $location === path;
   };
 
+  // A proxy-managed session is owned by the identity provider, not by us.
+  const isProxyManagedSession = $derived(
+    $auth.user?.auth_source === "forward_auth",
+  );
+  const proxyLogoutUrl = $derived($auth.user?.logout_url ?? null);
+
   // logout handler
   const handleLogout = async () => {
+    // Capture before auth.logout() clears $auth.user, which would otherwise
+    // make these derived values go stale (false/null) before we read them.
+    const redirectUrl = isProxyManagedSession ? proxyLogoutUrl : null;
     await auth.logout();
+    if (redirectUrl) {
+      window.location.href = redirectUrl;
+    }
   };
 
   const isShown = (path: string): boolean => !hiddenPaths.includes(path);
@@ -403,21 +416,37 @@
           </div>
         </div>
 
-        <!-- logout button -->
-        <button
-          onmouseenter={() => (logoutHovered = true)}
-          onmouseleave={() => (logoutHovered = false)}
-          onclick={handleLogout}
-          class="w-full flex justify-center items-center gap-3 px-4 py-2 rounded-lg text-muted-foreground
-            hover:bg-destructive/10 hover:text-destructive transition-colors duration-200 cursor-pointer mt-1"
-        >
-          {#if logoutHovered}
-            <DoorOpen />
-          {:else}
-            <DoorClosed />
-          {/if}
-          <span class="font-medium">Logout</span>
-        </button>
+        <!-- logout button, or a label when the identity provider owns the session -->
+        {#if !isProxyManagedSession || proxyLogoutUrl}
+          <button
+            onmouseenter={() => (logoutHovered = true)}
+            onmouseleave={() => (logoutHovered = false)}
+            onclick={handleLogout}
+            class="w-full flex justify-center items-center gap-3 px-4 py-2 rounded-lg text-muted-foreground
+              hover:bg-destructive/10 hover:text-destructive transition-colors duration-200 cursor-pointer mt-1"
+          >
+            {#if logoutHovered}
+              <DoorOpen />
+            {:else}
+              <DoorClosed />
+            {/if}
+            <span class="font-medium">Logout</span>
+          </button>
+        {:else}
+          <Tooltip.Root>
+            <Tooltip.Trigger
+              class="w-full flex justify-center items-center gap-3 px-4 py-2 rounded-lg
+                text-muted-foreground cursor-default mt-1"
+            >
+              <ShieldCheck />
+              <span class="font-medium">Managed by SSO</span>
+            </Tooltip.Trigger>
+            <Tooltip.Content side="top">
+              Your session is managed by your identity provider. Sign out there
+              to end it.
+            </Tooltip.Content>
+          </Tooltip.Root>
+        {/if}
       </div>
     {/if}
   </div>

--- a/frontend/src/lib/types/shared.ts
+++ b/frontend/src/lib/types/shared.ts
@@ -44,6 +44,8 @@ export enum PageAccess {
 export interface UserProfile extends User {
   avatar_url: string | null;
   created_at: string;
+  auth_source?: "forward_auth" | "local";
+  logout_url?: string | null;
 }
 
 export interface AccountSession {

--- a/tests/test_current_user_info.py
+++ b/tests/test_current_user_info.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from backend.api.routes.account import router as account_router
+from backend.core.auth import get_current_user
+from backend.core.settings import settings
+from backend.enums import UserRole
+from backend.models.auth import CurrentUserInfo
+
+
+class _FakeUser:
+    id = 1
+    username = "alice"
+    display_name = "Alice"
+    email = None
+    avatar_path = None
+    role = UserRole.ADMIN
+    permissions: list[str] = []
+    allowed_pages = None
+    created_at = datetime.now(UTC)
+    password_hash = "hashed"
+    require_password_change = False
+
+
+def test_forward_auth_session_carries_source_and_logout_url() -> None:
+    info = CurrentUserInfo.from_current_user(
+        _FakeUser(),
+        auth_source="forward_auth",
+        logout_url="https://auth.example.com/logout",
+    )
+
+    assert info.username == "alice"
+    assert info.auth_source == "forward_auth"
+    assert info.logout_url == "https://auth.example.com/logout"
+
+
+def test_local_session_reports_local_source_and_no_logout_url() -> None:
+    info = CurrentUserInfo.from_current_user(
+        _FakeUser(), auth_source="local", logout_url=None
+    )
+
+    assert info.auth_source == "local"
+    assert info.logout_url is None
+
+
+def _client_for(auth_method: str | None) -> TestClient:
+    app = FastAPI()
+    app.include_router(account_router)
+
+    async def _current_user(request: Request) -> _FakeUser:
+        if auth_method is not None:
+            request.state.auth_method = auth_method
+        return _FakeUser()
+
+    app.dependency_overrides[get_current_user] = _current_user
+    return TestClient(app)
+
+
+def test_me_reports_forward_auth_with_configured_logout_url(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "forward_auth_logout_url", "https://auth.example.com/logout"
+    )
+
+    body = _client_for("forward_auth").get("/api/account/me").json()
+
+    assert body["auth_source"] == "forward_auth"
+    assert body["logout_url"] == "https://auth.example.com/logout"
+
+
+def test_me_reports_forward_auth_without_logout_url(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "forward_auth_logout_url", "")
+
+    body = _client_for("forward_auth").get("/api/account/me").json()
+
+    assert body["auth_source"] == "forward_auth"
+    assert body["logout_url"] is None
+
+
+def test_me_reports_local_session_and_never_leaks_the_logout_url(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "forward_auth_logout_url", "https://auth.example.com/logout"
+    )
+
+    body = _client_for(None).get("/api/account/me").json()
+
+    assert body["auth_source"] == "local"
+    assert body["logout_url"] is None

--- a/tests/test_forward_auth.py
+++ b/tests/test_forward_auth.py
@@ -490,6 +490,63 @@ def test_invalid_asserted_usernames_are_rejected(monkeypatch, username: str) -> 
     asyncio.run(run())
 
 
+def test_missing_wrapper_state_warns_accurately(monkeypatch, caplog) -> None:
+    _configure_forward_auth(monkeypatch)
+    auth_module._forward_auth_warned_missing_wrapper = False
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            with caplog.at_level(logging.WARNING):
+                with pytest.raises(HTTPException) as exc:
+                    await get_current_user(_request_without_wrapper_state(), db)
+
+            assert exc.value.status_code == 401
+            assert exc.value.detail == "Not authenticated"
+
+            record = next(r for r in caplog.records if r.levelno == logging.WARNING)
+            assert "proxy header wrapper" in record.getMessage()
+            assert "untrusted peer" not in record.getMessage()
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_all_address_range_assigned_directly_does_not_confer_trust(
+    monkeypatch,
+) -> None:
+    _configure_forward_auth(monkeypatch)
+    # Bypass validate_forward_auth_trusted_proxies entirely: Settings does not
+    # set validate_assignment, so a direct attribute assignment (as opposed to
+    # construction from the environment) skips the field validator. This is
+    # exactly the gap _parse_trusted_networks must re-close.
+    monkeypatch.setattr(settings, "forward_auth_trusted_proxies", "0.0.0.0/0")
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            db.add(
+                User(
+                    username="admin",
+                    password_hash="hashed",
+                    role=UserRole.ADMIN,
+                    permissions=[],
+                )
+            )
+            await db.commit()
+
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user(
+                    _request(username="admin", original_client="198.51.100.23"), db
+                )
+
+            assert exc.value.status_code == 401
+            assert exc.value.detail == "Not authenticated"
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
 def test_username_matching_is_case_sensitive(monkeypatch) -> None:
     """Pins case sensitivity, which currently comes from SQLite's BINARY
     collation rather than from anything declared in the model."""

--- a/tests/test_forward_auth.py
+++ b/tests/test_forward_auth.py
@@ -443,3 +443,76 @@ def test_repeated_untrusted_peers_warn_once(monkeypatch, caplog) -> None:
         await engine.dispose()
 
     asyncio.run(run())
+
+
+def test_header_is_ignored_when_forward_auth_is_disabled(monkeypatch) -> None:
+    _configure_forward_auth(monkeypatch)
+    monkeypatch.setattr(settings, "forward_auth_enabled", False)
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            db.add(
+                User(
+                    username="admin",
+                    password_hash="hashed",
+                    role=UserRole.ADMIN,
+                    permissions=[],
+                )
+            )
+            await db.commit()
+
+            # Trusted peer, valid user, correct header, but the feature is off.
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user(_request(username="admin"), db)
+
+            assert exc.value.status_code == 401
+            assert exc.value.detail == "Not authenticated"
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("username", ["", "   ", "a" * 33])
+def test_invalid_asserted_usernames_are_rejected(monkeypatch, username: str) -> None:
+    _configure_forward_auth(monkeypatch)
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user(_request(username=username), db)
+
+            assert exc.value.status_code == 401
+            assert exc.value.detail == "Trusted proxy supplied an invalid username"
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_username_matching_is_case_sensitive(monkeypatch) -> None:
+    """Pins case sensitivity, which currently comes from SQLite's BINARY
+    collation rather than from anything declared in the model."""
+    _configure_forward_auth(monkeypatch)
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            db.add(
+                User(
+                    username="carol",
+                    password_hash="hashed",
+                    role=UserRole.USER,
+                    permissions=[],
+                )
+            )
+            await db.commit()
+
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user(_request(username="Carol"), db)
+
+            assert exc.value.status_code == 401
+            assert exc.value.detail == "Trusted proxy user is not configured"
+        await engine.dispose()
+
+    asyncio.run(run())

--- a/tests/test_forward_auth.py
+++ b/tests/test_forward_auth.py
@@ -343,3 +343,74 @@ def test_missing_wrapper_state_is_not_trusted(monkeypatch) -> None:
         await engine.dispose()
 
     asyncio.run(run())
+
+
+def test_unknown_identity_falls_back_to_cookie_when_recovery_enabled(
+    monkeypatch,
+) -> None:
+    _configure_forward_auth(monkeypatch)
+    monkeypatch.setattr(settings, "forward_auth_allow_local_fallback", True)
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            user = User(
+                username="local-admin",
+                password_hash="hashed",
+                role=UserRole.ADMIN,
+                permissions=[],
+            )
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+            session_id = "recovery-session"
+            db.add(
+                UserSession(
+                    user_id=user.id,
+                    session_id=session_id,
+                    expires_at=datetime.now(UTC) + timedelta(hours=1),
+                )
+            )
+            await db.commit()
+            cookie = create_access_token(
+                data={"sub": str(user.id)},
+                token_version=user.token_version,
+                session_id=session_id,
+            )
+
+            request = _request(username="unknown-user", cookie=cookie)
+            authenticated = await get_current_user(request, db)
+
+            assert authenticated.username == "local-admin"
+            assert getattr(request.state, "auth_method", None) is None
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_disabled_identity_is_rejected_even_when_recovery_enabled(monkeypatch) -> None:
+    _configure_forward_auth(monkeypatch)
+    monkeypatch.setattr(settings, "forward_auth_allow_local_fallback", True)
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            db.add(
+                User(
+                    username="disabled-user",
+                    password_hash="hashed",
+                    role=UserRole.USER,
+                    permissions=[],
+                    is_active=False,
+                )
+            )
+            await db.commit()
+
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user(_request(username="disabled-user"), db)
+
+            assert exc.value.status_code == 403
+        await engine.dispose()
+
+    asyncio.run(run())

--- a/tests/test_forward_auth.py
+++ b/tests/test_forward_auth.py
@@ -52,6 +52,23 @@ def _request(
     )
 
 
+def _request_without_wrapper_state(username: str = "alice") -> Request:
+    """A request as it would arrive if the proxy-header wrapper never ran."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/account/me",
+            "headers": [(b"remote-user", username.encode())],
+            "query_string": b"",
+            "client": ("172.18.0.4", 4242),
+            "scheme": "https",
+            "server": ("reclaimerr.example", 443),
+            "state": {},
+        }
+    )
+
+
 async def _session_maker() -> tuple[AsyncEngine, async_sessionmaker[AsyncSession]]:
     engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
     async with engine.begin() as conn:
@@ -295,6 +312,34 @@ def test_missing_forward_auth_header_preserves_cookie_auth(monkeypatch) -> None:
 
             assert authenticated.username == "cookie-user"
             assert getattr(request.state, "auth_method", None) is None
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_missing_wrapper_state_is_not_trusted(monkeypatch) -> None:
+    _configure_forward_auth(monkeypatch)
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            db.add(
+                User(
+                    username="alice",
+                    password_hash="hashed",
+                    role=UserRole.USER,
+                    permissions=[],
+                )
+            )
+            await db.commit()
+
+            # The socket peer is a trusted proxy IP, but the wrapper never
+            # recorded it, so the header must be ignored rather than trusted.
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user(_request_without_wrapper_state(), db)
+
+            assert exc.value.status_code == 401
+            assert exc.value.detail == "Not authenticated"
         await engine.dispose()
 
     asyncio.run(run())

--- a/tests/test_forward_auth.py
+++ b/tests/test_forward_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -13,6 +14,7 @@ from sqlalchemy.ext.asyncio import (
 )
 from starlette.requests import Request
 
+from backend.core import auth as auth_module
 from backend.core.auth import (
     COOKIE_NAME,
     ORIGINAL_CLIENT_HOST_STATE_KEY,
@@ -411,6 +413,33 @@ def test_disabled_identity_is_rejected_even_when_recovery_enabled(monkeypatch) -
                 await get_current_user(_request(username="disabled-user"), db)
 
             assert exc.value.status_code == 403
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_repeated_untrusted_peers_warn_once(monkeypatch, caplog) -> None:
+    _configure_forward_auth(monkeypatch)
+    auth_module._forward_auth_warned_peers.clear()
+
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            with caplog.at_level(logging.WARNING):
+                for _ in range(3):
+                    with pytest.raises(HTTPException):
+                        await get_current_user(
+                            _request(username="admin", original_client="192.0.2.77"),
+                            db,
+                        )
+
+            warnings = [
+                record
+                for record in caplog.records
+                if "untrusted peer" in record.getMessage()
+                and record.levelno == logging.WARNING
+            ]
+            assert len(warnings) == 1
         await engine.dispose()
 
     asyncio.run(run())

--- a/tests/test_forward_auth_notice.py
+++ b/tests/test_forward_auth_notice.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from backend.database import Base
+from backend.database.models import AdminNotice
+from backend.services.admin_notices import (
+    NOTICE_KEY_FORWARD_AUTH_FALLBACK,
+    sync_forward_auth_fallback_notice,
+)
+
+
+async def _session_maker() -> tuple[AsyncEngine, async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+
+async def _fetch_notice(db: AsyncSession) -> AdminNotice | None:
+    return (
+        await db.execute(
+            select(AdminNotice).where(
+                AdminNotice.dedupe_key == NOTICE_KEY_FORWARD_AUTH_FALLBACK
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def test_notice_is_raised_while_recovery_mode_is_active() -> None:
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            await sync_forward_auth_fallback_notice(db, fallback_active=True)
+            await db.commit()
+
+            notice = await _fetch_notice(db)
+            assert notice is not None
+            assert notice.is_active is True
+            assert notice.severity == "warning"
+            assert "FORWARD_AUTH_ALLOW_LOCAL_FALLBACK" in notice.message
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_notice_resolves_when_recovery_mode_is_switched_off() -> None:
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            await sync_forward_auth_fallback_notice(db, fallback_active=True)
+            await db.commit()
+
+            await sync_forward_auth_fallback_notice(db, fallback_active=False)
+            await db.commit()
+
+            notice = await _fetch_notice(db)
+            assert notice is not None
+            assert notice.is_active is False
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_no_notice_is_created_when_recovery_mode_was_never_on() -> None:
+    async def run() -> None:
+        engine, session_maker = await _session_maker()
+        async with session_maker() as db:
+            await sync_forward_auth_fallback_notice(db, fallback_active=False)
+            await db.commit()
+
+            assert await _fetch_notice(db) is None
+        await engine.dispose()
+
+    asyncio.run(run())

--- a/tests/test_proxy_headers.py
+++ b/tests/test_proxy_headers.py
@@ -7,6 +7,8 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 import backend.api.main as api_main
+from backend.core.auth import _is_forward_auth_proxy_trusted
+from backend.core.settings import settings
 
 
 async def _oidc_start(request: Request) -> PlainTextResponse:
@@ -27,6 +29,10 @@ async def _oidc_callback(_request: Request) -> PlainTextResponse:
     return PlainTextResponse("ok")
 
 
+async def _forward_auth_trusted(request: Request) -> PlainTextResponse:
+    return PlainTextResponse(str(_is_forward_auth_proxy_trusted(request)))
+
+
 def _build_client(*, trusted_hosts: list[str] | str) -> TestClient:
     base_app = Starlette(
         routes=[
@@ -34,6 +40,7 @@ def _build_client(*, trusted_hosts: list[str] | str) -> TestClient:
             Route("/scheme", _scheme, name="scheme"),
             Route("/client-hosts", _client_hosts, name="client_hosts"),
             Route("/api/auth/oidc/callback", _oidc_callback, name="oidc_callback"),
+            Route("/forward-auth-trusted", _forward_auth_trusted, name="fa_trusted"),
         ]
     )
     wrapped_app = api_main._wrap_proxy_headers(  # pyright: ignore[reportPrivateUsage]
@@ -95,3 +102,23 @@ def test_proxy_wrapper_preserves_socket_peer_before_forwarded_rewrite() -> None:
 
     assert response.status_code == 200
     assert response.text == "testclient|203.0.113.10"
+
+
+def test_forwarded_for_cannot_forge_the_forward_auth_trust_decision(
+    monkeypatch,
+) -> None:
+    """The whole point of the wrapper: even with PROXY_TRUSTED_HOSTS='*', an
+    untrusted client cannot use X-Forwarded-For to look like the trusted proxy."""
+    monkeypatch.setattr(settings, "forward_auth_enabled", True)
+    monkeypatch.setattr(settings, "forward_auth_trusted_proxies", "172.18.0.4")
+
+    client = _build_client(trusted_hosts="*")
+
+    response = client.get(
+        "/forward-auth-trusted",
+        headers={"X-Forwarded-For": "172.18.0.4"},
+    )
+
+    assert response.status_code == 200
+    # The socket peer is 'testclient', not the spoofed 172.18.0.4.
+    assert response.text == "False"

--- a/tests/test_settings_log_level.py
+++ b/tests/test_settings_log_level.py
@@ -127,6 +127,16 @@ def test_forward_auth_rejects_wildcard_proxy(monkeypatch, tmp_path: Path) -> Non
         _build_settings(tmp_path)
 
 
+@pytest.mark.parametrize("value", ["0.0.0.0/0", "::/0", "172.18.0.4,0.0.0.0/0"])
+def test_forward_auth_rejects_all_address_ranges(
+    monkeypatch, tmp_path: Path, value: str
+) -> None:
+    monkeypatch.setenv("FORWARD_AUTH_TRUSTED_PROXIES", value)
+
+    with pytest.raises(ValueError, match="does not accept"):
+        _build_settings(tmp_path)
+
+
 def test_forward_auth_parses_ip_and_cidr_allowlist(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("FORWARD_AUTH_TRUSTED_PROXIES", "172.18.0.4, 10.20.0.0/16, ::1")
     monkeypatch.setenv("FORWARD_AUTH_USER_HEADER", "X-Authenticated-User")

--- a/tests/test_settings_log_level.py
+++ b/tests/test_settings_log_level.py
@@ -192,3 +192,9 @@ def test_invalid_command_workers_falls_back_to_two(
     settings = _build_settings(tmp_path)
 
     assert settings.command_workers == 2
+
+
+def test_forward_auth_local_fallback_defaults_off(tmp_path: Path) -> None:
+    settings = _build_settings(tmp_path)
+
+    assert settings.forward_auth_allow_local_fallback is False

--- a/tests/test_settings_log_level.py
+++ b/tests/test_settings_log_level.py
@@ -198,3 +198,31 @@ def test_forward_auth_local_fallback_defaults_off(tmp_path: Path) -> None:
     settings = _build_settings(tmp_path)
 
     assert settings.forward_auth_allow_local_fallback is False
+
+
+def test_forward_auth_logout_url_defaults_empty(tmp_path: Path) -> None:
+    settings = _build_settings(tmp_path)
+
+    assert settings.forward_auth_logout_url == ""
+
+
+def test_forward_auth_logout_url_accepts_absolute_https(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("FORWARD_AUTH_LOGOUT_URL", " https://auth.example.com/logout ")
+
+    settings = _build_settings(tmp_path)
+
+    assert settings.forward_auth_logout_url == "https://auth.example.com/logout"
+
+
+@pytest.mark.parametrize(
+    "value", ["javascript:alert(1)", "/logout", "auth.example.com/logout", "ftp://x/y"]
+)
+def test_forward_auth_logout_url_rejects_non_http(
+    monkeypatch, tmp_path: Path, value: str
+) -> None:
+    monkeypatch.setenv("FORWARD_AUTH_LOGOUT_URL", value)
+
+    with pytest.raises(ValueError, match="absolute http or https URL"):
+        _build_settings(tmp_path)


### PR DESCRIPTION
Targets `forward-auth`, not `dev`. This builds on that feature rather than replacing it.

A review of `forward-auth` raised ten issues. This resolves all ten, each with its own tests.

## Security

`FORWARD_AUTH_TRUSTED_PROXIES` rejected `*` but accepted `0.0.0.0/0`, which is the same thing written differently. Anyone able to reach the backend port could then assert any username, including an admin. It now rejects any entry with a zero-length prefix, and the runtime parser re-checks the rule because `Settings` does not set `validate_assignment`.

`_get_original_client_host` fell back to `request.client.host` when the pre-rewrite socket-peer snapshot was missing — precisely the case where that value may already have been rewritten from `X-Forwarded-For`. It now returns `None` and the request falls through to cookie auth.

Added the end-to-end test the feature was missing: with `PROXY_TRUSTED_HOSTS=*`, a spoofed `X-Forwarded-For` still cannot forge the trust decision.

## Recovery from lockout

An asserted username matching no local user raised 401 before the cookie path was reached. That 401 hit every authenticated endpoint, including the one needed to create the missing user, and the setup wizard closes once an admin exists — so there was no in-product recovery.

`FORWARD_AUTH_ALLOW_LOCAL_FALLBACK` (default off) lets an unmatched identity fall through to local cookie login. It lowers no authentication bar: that path still requires a signed JWT, a matching token version and a live session row. A known-but-disabled user is refused in both modes. While the switch is on, startup logs a warning and an admin notice stays visible in the sidebar.

## Logout

Under forward auth the session belongs to the identity provider, so clearing the local cookie did nothing and the logout button silently failed. `GET /api/account/me` now reports `auth_source` and `logout_url`, and the sidebar either replaces the control with a "Managed by SSO" label or, when `FORWARD_AUTH_LOGOUT_URL` is set, redirects to the provider's sign-out endpoint.

## Documentation

Setup order, the exact-match username requirement, the recovery procedure, and a Caddy example that strips the identity header before the auth step. That example uses a `route` block deliberately: Caddy's built-in directive order runs `forward_auth` before `request_header`, so without it the strip would happen after authentication and the example would not do what it claims. Also records that the app relies on `SameSite=lax` cookies and has no CSRF tokens, so under forward auth cross-site protection depends on the proxy's session cookie configuration.

## Other

The proxy allowlist is parsed once per distinct value rather than on every authenticated request. Untrusted peers presenting the header warn once each rather than on every request, so probing cannot flood the log. When the ASGI proxy-header wrapper has not run, the log now says so accurately instead of reporting an untrusted peer of "unknown", which pointed at the wrong setting.

## Not changed, deliberately

Username matching stays exact and case-sensitive, now pinned by a test. No auto-provisioning: the feature never creates accounts or grants roles. No CSRF tokens.

## New settings

Both default off, so existing deployments are unaffected: `FORWARD_AUTH_ALLOW_LOCAL_FALLBACK` and `FORWARD_AUTH_LOGOUT_URL`.

## Verification

708 tests pass, up from 678 on `forward-auth`. `svelte-check` and the frontend build are clean, and the docs build passes with `--strict`.
